### PR TITLE
Fix collisions in DF17 error table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,14 @@ target_compile_definitions(stream1090 PRIVATE
 
 target_link_libraries(stream1090 PRIVATE ${DEVICE_LIBS})
 
+include(CTest)
+if(BUILD_TESTING)
+    add_executable(crc_error_table_test tests/CRCErrorTableTest.cpp)
+    target_include_directories(crc_error_table_test PRIVATE include)
+    target_compile_options(crc_error_table_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME crc_error_table_test COMMAND crc_error_table_test)
+endif()
+
 # ------------------------------------------------------------
 # table_gen (excluded from all)
 # ------------------------------------------------------------

--- a/include/CRCErrorTable.hpp
+++ b/include/CRCErrorTable.hpp
@@ -70,7 +70,7 @@ namespace CRC {
 
 
 	// Error correction table used for extended squitter messages
-	class DF17ErrorTableExperimental : public BaseErrorTable<4859> {
+	class DF17ErrorTableExperimental : public BaseErrorTable<6790> {
 	public:
 		constexpr DF17ErrorTableExperimental() {
 			// one bit error correction excluding the DF part

--- a/table_gen.cpp
+++ b/table_gen.cpp
@@ -53,6 +53,11 @@ void generateKeySetExtSquitterBurst(std::vector<crc_t>& keys) {
     for (int i = 0; i < 16; i++) {
         keys.push_back(compute(encodeFixOp(129,i)));
     }
+
+    // two bit errors with one correct bit in between (101)
+    for (int i = 0; i < 110-5; i++) {
+        keys.push_back(compute(encodeFixOp(0x5,i)));
+    }
 }
 
 void generateKeySetShort1Bit(std::vector<crc_t>& keys) {
@@ -83,7 +88,7 @@ int testTableSize(const std::vector<crc_t>& keys, int tableSize) {
 }
 
 int bruteforceMinTableSize(const std::vector<crc_t>& keys) {
-    for (int N = keys.size(); N < 6000; N++) {
+    for (int N = keys.size(); N < 10000; N++) {
         int res = testTableSize(keys, N);
         if (res == 1) {
             return N;

--- a/tests/CRCErrorTableTest.cpp
+++ b/tests/CRCErrorTableTest.cpp
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "CRCErrorTable.hpp"
+
+namespace {
+
+constexpr bool finds(const auto& table, uint8_t pattern, uint8_t index) {
+    const auto expected = CRC::encodeFixOp(pattern, index);
+    const auto actual = table.lookup(CRC::compute(expected));
+    return actual.pattern == expected.pattern && actual.index == expected.index;
+}
+
+constexpr bool validatesDF17Table() {
+    for (int i = 0; i < 112 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x1, i)) return false;
+    for (int i = 0; i < 111 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x3, i)) return false;
+    for (int i = 0; i < 110 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x7, i)) return false;
+    for (int i = 0; i < 16; ++i)
+        if (!finds(CRC::df17ErrorTable, 129, i)) return false;
+    for (int i = 0; i < 110 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x5, i)) return false;
+    return true;
+}
+
+constexpr bool validatesDF11Table() {
+    for (int i = 0; i < 56 - 5; ++i)
+        if (!finds(CRC::df11ErrorTable, 0x1, i)) return false;
+    for (int i = 0; i < 55 - 5; ++i)
+        if (!finds(CRC::df11ErrorTable, 0x3, i)) return false;
+    return true;
+}
+
+static_assert(validatesDF17Table());
+static_assert(validatesDF11Table());
+
+} // namespace
+
+int main() {}


### PR DESCRIPTION
Hello, Enrico here. I've been playing with stream1090 and this small change seems to improve the decode a bit. Thanks for considering it.



## Summary

- include the existing `101` correction pattern in the advanced DF17 table generator
- resize the advanced DF17 error table from 4,859 to the generated collision-free size of 6,790
- add a CTest regression test that verifies every declared DF17 and DF11 correction remains reachable

## Why

`BaseErrorTable` uses direct modulo indexing and silently skips an insertion when two CRC syndromes map to the same slot. The advanced DF17 table already declared the `101` correction family, but `table_gen` did not include that family when choosing the table size. As a result, the old size allowed collisions and some declared corrections were unavailable at lookup time.

## Validation

```text
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
cmake --build build --target crc_error_table_test table_gen --parallel
ctest --test-dir build --output-on-failure
```

The regression test passes, and `table_gen` reports:

```text
DF17 min table size with advanced correction: 6790
```
