### PR TITLE
Expand DF17 two-bit correction patterns

### DIFF
--- a/README_ADV.md
+++ b/README_ADV.md
@@ -76,6 +76,8 @@ For ```airspy_rx``` this works the same way. However, make sure that your sample
     cat ./samples.bin | ./build/stream1090 -s 10 -u 24 > /dev/null
     ```
 
+When changing the CRC correction patterns, build and run the `table_gen` target to confirm the declared pattern count. The advanced table uses open addressing to preserve colliding entries. Then run CTest: `crc_error_table_test` verifies that every declared DF17 and DF11 correction remains reachable from its CRC syndrome.
+
 Important: If you want to see the statistics for the whole file and not every 5 seconds. You can enable the a summary at the end by rebuilding stream with after the following cmake call in the build directory
 ```
 cmake ../ --fresh -DEND_STATS=ON -DENABLE_STATS=ON && make

--- a/include/CRCErrorTable.hpp
+++ b/include/CRCErrorTable.hpp
@@ -15,7 +15,7 @@
 namespace CRC {
 
 	// the base class for an error correcting ("hash") table of fixed size
-	template<size_t size>
+	template<size_t size, bool resolveCollisions = false>
 	class BaseErrorTable {
 	public:
 		constexpr BaseErrorTable() : m_keys(), m_ops() {
@@ -26,9 +26,28 @@ namespace CRC {
 		}
 		
 		constexpr fixop_t lookup(crc_t crc) const noexcept {
-			int index = crc % size;
-			if (m_keys[index] == crc) {
-				return m_ops[index];
+			size_t index = crc % size;
+			if constexpr (!resolveCollisions) {
+				if (m_keys[index] == crc) {
+					return m_ops[index];
+				}
+			} else {
+				const auto homeKey = m_keys[index];
+				if ((homeKey & ~collisionFlag) == crc) {
+					return m_ops[index];
+				}
+				if ((homeKey & collisionFlag) == 0) {
+					return fixop_t({0,0});
+				}
+				for (size_t probe = 1; probe < size; probe++) {
+					index = (index + 1 == size) ? 0 : index + 1;
+					if ((m_keys[index] & ~collisionFlag) == crc) {
+						return m_ops[index];
+					}
+					if (m_keys[index] == 0) {
+						break;
+					}
+				}
 			}
 			return fixop_t({0,0});
 		}
@@ -36,13 +55,40 @@ namespace CRC {
 	protected:
 		constexpr void insert(fixop_t op) noexcept {
 			crc_t crc = compute(op);
-			int i = crc % size;
-			if (m_keys[i] == 0) {
-				m_keys[i] = crc;
-				m_ops[i] = op;
+			size_t index = crc % size;
+			if constexpr (!resolveCollisions) {
+				if (m_keys[index] == 0) {
+					m_keys[index] = crc;
+					m_ops[index] = op;
+				}
+			} else {
+				if (m_keys[index] == 0) {
+					m_keys[index] = crc;
+					m_ops[index] = op;
+					return;
+				}
+				if ((m_keys[index] & ~collisionFlag) == crc) {
+					m_ops[index] = op;
+					return;
+				}
+				m_keys[index] |= collisionFlag;
+				for (size_t probe = 1; probe < size; probe++) {
+					index = (index + 1 == size) ? 0 : index + 1;
+					if (m_keys[index] == 0) {
+						m_keys[index] = crc;
+						m_ops[index] = op;
+						return;
+					}
+					if ((m_keys[index] & ~collisionFlag) == crc) {
+						m_ops[index] = op;
+						return;
+					}
+				}
 			}
 		}
 	private:
+		// CRC syndromes use 24 bits, leaving the top bit free to mark collision chains.
+		static constexpr crc_t collisionFlag = crc_t{1} << 31;
 		std::array<crc_t, size> m_keys;	
 		std::array<fixop_t, size> m_ops;
 	};
@@ -70,7 +116,7 @@ namespace CRC {
 
 
 	// Error correction table used for extended squitter messages
-	class DF17ErrorTableExperimental : public BaseErrorTable<6790> {
+	class DF17ErrorTableExperimental : public BaseErrorTable<6790, true> {
 	public:
 		constexpr DF17ErrorTableExperimental() {
 			// one bit error correction excluding the DF part
@@ -89,13 +135,33 @@ namespace CRC {
 			}
 
 			// 1 000000 1 pattern shifted through the parity part
-			for (int i = 0; i < 16; i++) {
+			for (int i = 0; i < 105-5; i++) {
 				insert(encodeFixOp(129,i));
 			}
 
 			// try inserting 101 bit errors into the table. Not all of them may fit
 			for (int i = 0; i < 110-5; i++) {
 				insert(encodeFixOp(0x5,i));
+			}
+
+			// try two bit errors with two correct bits in between (1001)
+			for (int i = 0; i < 109-5; i++) {
+				insert(encodeFixOp(0x9,i));
+			}
+
+			// try two bit errors with three correct bits in between (10001)
+			for (int i = 0; i < 108-5; i++) {
+				insert(encodeFixOp(0x11,i));
+			}
+
+			// try two bit errors with four correct bits in between (100001)
+			for (int i = 0; i < 107-5; i++) {
+				insert(encodeFixOp(0x21,i));
+			}
+
+			// try two bit errors with five correct bits in between (1000001)
+			for (int i = 0; i < 106-5; i++) {
+				insert(encodeFixOp(0x41,i));
 			}
 		}
 	};

--- a/table_gen.cpp
+++ b/table_gen.cpp
@@ -50,13 +50,33 @@ void generateKeySetExtSquitterBurst(std::vector<crc_t>& keys) {
     }
 
     // this seems to help, for the parity block
-    for (int i = 0; i < 16; i++) {
+    for (int i = 0; i < 105-5; i++) {
         keys.push_back(compute(encodeFixOp(129,i)));
     }
 
     // two bit errors with one correct bit in between (101)
     for (int i = 0; i < 110-5; i++) {
         keys.push_back(compute(encodeFixOp(0x5,i)));
+    }
+
+    // two bit errors with two correct bits in between (1001)
+    for (int i = 0; i < 109-5; i++) {
+        keys.push_back(compute(encodeFixOp(0x9,i)));
+    }
+
+    // two bit errors with three correct bits in between (10001)
+    for (int i = 0; i < 108-5; i++) {
+        keys.push_back(compute(encodeFixOp(0x11,i)));
+    }
+
+    // two bit errors with four correct bits in between (100001)
+    for (int i = 0; i < 107-5; i++) {
+        keys.push_back(compute(encodeFixOp(0x21,i)));
+    }
+
+    // two bit errors with five correct bits in between (1000001)
+    for (int i = 0; i < 106-5; i++) {
+        keys.push_back(compute(encodeFixOp(0x41,i)));
     }
 }
 
@@ -88,7 +108,7 @@ int testTableSize(const std::vector<crc_t>& keys, int tableSize) {
 }
 
 int bruteforceMinTableSize(const std::vector<crc_t>& keys) {
-    for (int N = keys.size(); N < 10000; N++) {
+    for (int N = keys.size(); N < 30000; N++) {
         int res = testTableSize(keys, N);
         if (res == 1) {
             return N;
@@ -106,7 +126,7 @@ int runExtSquitter() {
 int runExtSquitterBurst() {
     std::vector<crc_t> keys;
     generateKeySetExtSquitterBurst(keys);
-    return bruteforceMinTableSize(keys);
+    return keys.size();
 }
 
 int runOneBitShort() {
@@ -123,7 +143,7 @@ int runTwoBitShort() {
 
 int main(/*int argc, char** argv*/) {
     std::cout << "DF17 min table size: " << runExtSquitter() << std::endl;
-    std::cout << "DF17 min table size with advanced correction: " << runExtSquitterBurst() << std::endl;
+    std::cout << "DF17 advanced correction patterns: " << runExtSquitterBurst() << std::endl;
     std::cout << "DF11 one bit short message min table size: " << runOneBitShort() << std::endl;
     std::cout << "DF11 one bit short message min table size: " << runTwoBitShort() << std::endl;
     return 0;

--- a/tests/CRCErrorTableTest.cpp
+++ b/tests/CRCErrorTableTest.cpp
@@ -17,10 +17,18 @@ constexpr bool validatesDF17Table() {
         if (!finds(CRC::df17ErrorTable, 0x3, i)) return false;
     for (int i = 0; i < 110 - 5; ++i)
         if (!finds(CRC::df17ErrorTable, 0x7, i)) return false;
-    for (int i = 0; i < 16; ++i)
+    for (int i = 0; i < 105 - 5; ++i)
         if (!finds(CRC::df17ErrorTable, 129, i)) return false;
     for (int i = 0; i < 110 - 5; ++i)
         if (!finds(CRC::df17ErrorTable, 0x5, i)) return false;
+    for (int i = 0; i < 109 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x9, i)) return false;
+    for (int i = 0; i < 108 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x11, i)) return false;
+    for (int i = 0; i < 107 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x21, i)) return false;
+    for (int i = 0; i < 106 - 5; ++i)
+        if (!finds(CRC::df17ErrorTable, 0x41, i)) return false;
     return true;
 }
 


### PR DESCRIPTION
hello, please consider this one too. It gives me some decode improvement for free.

## Summary

- extend the advanced DF17 correction table with two-bit patterns separated by two through five correct bits
- cover the existing `10000001` pattern across the full non-DF portion of the frame
- preserve colliding CRC syndromes with an open-addressing fallback while keeping the table at 6,790 slots
- keep the probing path limited to the advanced DF17 table and to buckets that actually have collision chains
- extend the generator output, regression test, and advanced documentation

## Why

The advanced table currently corrects adjacent bursts and a small selection of separated two-bit errors. Extending the declared patterns recovers additional DF17 frames, but requiring a collision-free direct-index table would increase the table from 6,790 to 28,565 slots and caused measurable cache pressure.

This version keeps the existing 6,790-slot footprint. CRC syndromes use 24 bits, so the high bit of a stored key marks only those buckets that need linear probing. Non-colliding lookups retain the direct fast path, and other error tables retain their original lookup implementation.

## Validation

```text
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
cmake --build build --target stream1090 crc_error_table_test table_gen --parallel
ctest --test-dir build --output-on-failure
```

`crc_error_table_test` passes and verifies that all 933 declared advanced DF17 corrections remain reachable. `table_gen` reports:

```text
DF17 advanced correction patterns: 933
```

## Benchmark

Tested on a Raspberry Pi 4 (Cortex-A72, 1.5 GHz) with GCC 14.2, a fixed 10-second 6 Msps uint16 IQ capture, `-s 6 -u 24`, and two runs per variant after warming the page cache.

Capture SHA-256:

```text
cd8300dcd1d0cc43c6050e1c55bb4f5b18c4e80e561812415b02e5e9eb755dbb
```

With the IQ filter enabled (`-q`):

| Metric | main | this change | Difference |
| --- | ---: | ---: | ---: |
| DF17 messages | 934 | 951 | +17 (+1.82%) |
| Total messages | 6,035 | 6,052 | +17 (+0.28%) |

Without `-q`, DF17 messages increased from 639 to 648 (+1.41%). Repeated runs produced identical output checksums for each variant. All 17 additional filtered DF17 frames belonged to ICAO addresses already observed in the baseline capture.

Two paired `perf stat` runs of the final filtered implementation showed no task-clock regression within run-to-run variation. Compared with `main`, average instruction count changed by +0.35% and cache misses by +0.16%. The executable size changed from 581,616 to 581,688 bytes.
