### PR TITLE
Add opt-in multicore IQ preprocessing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,16 @@ if(BUILD_TESTING)
     target_include_directories(crc_error_table_test PRIVATE include)
     target_compile_options(crc_error_table_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME crc_error_table_test COMMAND crc_error_table_test)
+
+    find_package(Threads REQUIRED)
+    add_executable(async_magnitude_reader_test tests/AsyncMagnitudeReaderTest.cpp)
+    target_include_directories(async_magnitude_reader_test PRIVATE include)
+    target_compile_options(async_magnitude_reader_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    target_link_libraries(async_magnitude_reader_test PRIVATE Threads::Threads)
+    add_test(NAME async_magnitude_reader_test COMMAND async_magnitude_reader_test)
+
+    add_test(NAME cli_help_test COMMAND stream1090 --help)
+    set_tests_properties(cli_help_test PROPERTIES PASS_REGULAR_EXPRESSION "--multicore")
 endif()
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ To enable filtering use
 ```
 Stream1090 comes with a single filter for each sample rate combination. These have been optimized for a set of pre-recorded sample data provided by people from around the world with different setups.
 
+For hardware devices, `--multicore` moves IQ conversion, optional filtering, and magnitude calculation to a preprocessing thread. A bounded ring buffer then passes magnitude blocks to the sampling and demodulation thread. This keeps the stateful FIR ordered while allowing the scheduler to run the two CPU-heavy stages on separate cores. The default path and standard input mode remain synchronous.
+
+For Airspy input, `-q` enables the `DCRemoval`, `FlipSigns`, and `IQLowPass` stages. For RTL-SDR input it enables `IQLowPass` only.
+
 
 ## Stack Integration
 In order to utilize the output of Stream1090, we will send it to a decoder like readsb or dump1090-fa via TCP. This has one big advantage: You do not have to modify anything in the remaining stack.

--- a/include/AsyncMagnitudeReader.hpp
+++ b/include/AsyncMagnitudeReader.hpp
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "Global.hpp"
+#include "RingBuffer.hpp"
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <thread>
+
+template<typename InputReader, size_t BlockSize, size_t NumBlocks = 8>
+class AsyncMagnitudeReader {
+public:
+    // inputReader must outlive this object and be unblocked before destruction.
+    explicit AsyncMagnitudeReader(InputReader& inputReader)
+        : m_inputReader(inputReader),
+          m_writer(m_ringBuffer),
+          m_reader(m_ringBuffer),
+          m_thread([this] { produce(); })
+    { }
+
+    ~AsyncMagnitudeReader() {
+        m_stopRequested.store(true, std::memory_order_relaxed);
+        m_ringBuffer.shutdown();
+        if (m_thread.joinable())
+            m_thread.join();
+    }
+
+    AsyncMagnitudeReader(const AsyncMagnitudeReader&) = delete;
+    AsyncMagnitudeReader& operator=(const AsyncMagnitudeReader&) = delete;
+
+    void readMagnitude(float* out) noexcept {
+        m_reader.process([&](const float* block) {
+            std::memcpy(out, block, BlockSize * sizeof(float));
+        });
+    }
+
+    bool eof() {
+        return ProcessSignals::shutdownRequested() || m_reader.eof();
+    }
+
+private:
+    void produce() noexcept {
+        std::array<float, BlockSize> block;
+        while (!m_stopRequested.load(std::memory_order_relaxed) && !m_inputReader.eof()) {
+            m_inputReader.readMagnitude(block.data());
+            m_writer.write(block.data(), block.size());
+        }
+        m_writer.shutdown();
+    }
+
+    InputReader& m_inputReader;
+    RingBufferAsync<float, BlockSize, NumBlocks> m_ringBuffer;
+    typename RingBufferAsync<float, BlockSize, NumBlocks>::Writer m_writer;
+    typename RingBufferAsync<float, BlockSize, NumBlocks>::Reader m_reader;
+    std::atomic<bool> m_stopRequested{false};
+    std::thread m_thread;
+};

--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -12,6 +12,7 @@
 #include "SampleStream.hpp"
 #include "InputStreamReader.hpp"
 #include "InputBufferReader.hpp"
+#include "AsyncMagnitudeReader.hpp"
 #include "IQPipeline.hpp"
 #include "LowPassFilter.hpp"
 #include "devices/IniConfig.hpp"
@@ -43,6 +44,7 @@ struct RuntimeVars {
     IniConfig deviceConfig;
     IniConfig::Section deviceConfigSection;
     std::vector<float> filterTaps;
+    bool multicore = false;
     bool verbose = true;
 };
 
@@ -202,6 +204,11 @@ public:
         // DSP PIPELINE (blocking)
         // -------------------------------
         auto start_wct = std::chrono::steady_clock::now();
+        auto closeDevice = [this] {
+            log("[Stream1090] Shutting down device.");
+            m_device->close();
+            log("[Stream1090] Device closed down.");
+        };
 
         if (m_device->isRunning()) {
             log("[Stream1090] Device is running, starting stream.");
@@ -212,18 +219,27 @@ public:
                 decltype(iqPipeline)
             > inputReader(iqPipeline, ringBuffer);
 
-            SampleStream<SamplerType> sampleStream;
-            auto messageHandler = constructMessageHandler(sampleStream);
-            
-            sampleStream.read(inputReader, messageHandler);
-        }
+            auto readStream = [&](auto& reader) {
+                SampleStream<SamplerType> sampleStream;
+                auto messageHandler = constructMessageHandler(sampleStream);
+                sampleStream.read(reader, messageHandler);
+            };
 
-        // -------------------------------
-        // SHUTDOWN
-        // -------------------------------
-        log("[Stream1090] Shutting down device.");
-        m_device->close();
-        log("[Stream1090] Device closed down.");
+            if (m_runtimeVars.multicore) {
+                log("[Stream1090] Multicore preprocessing enabled.");
+                AsyncMagnitudeReader<
+                    decltype(inputReader),
+                    SamplerType::InputBufferSize
+                > asyncInputReader(inputReader);
+                readStream(asyncInputReader);
+                closeDevice();
+            } else {
+                readStream(inputReader);
+                closeDevice();
+            }
+        } else {
+            closeDevice();
+        }
 
         auto end_wct = std::chrono::steady_clock::now();
         auto dur_wct_secs = std::chrono::duration_cast<std::chrono::milliseconds>(end_wct - start_wct).count();

--- a/main.cpp
+++ b/main.cpp
@@ -119,6 +119,7 @@ void print_help() {
     "                       See configs/airspy.ini or configs/rtlsdr.ini\n"                       
     "  -q                   Enables IQ FIR filter with built-in taps\n"
     "  -f <taps file>       Taps to load that are used for the IQ FIR filter\n"
+    "  --multicore          Run IQ preprocessing on a separate thread\n"
     "  -v                   Verbose output\n"
     "  -h, --help           Show this help message\n\n";
 
@@ -137,6 +138,7 @@ struct CliArgs {
     std::string deviceConfig = "";
     std::string tapsFile = "";
     bool iq_filter = false;
+    bool multicore = false;
     bool verbose = false;
 };
 
@@ -171,6 +173,11 @@ bool parse_cli(int argc, char** argv, CliArgs& out) {
 
         if (arg == "-q") {
             out.iq_filter = true;
+            continue;
+        }
+
+        if (arg == "--multicore") {
+            out.multicore = true;
             continue;
         }
 
@@ -268,7 +275,7 @@ int main(int argc, char** argv) {
 
     CliArgs args;
     if (!parse_cli(argc, argv, args)) {
-        std::cerr << "Usage: stream1090 -s <rate> -u <rate> [-d <device.ini>] [-f <taps file>] [-q] [-v] [-h]\n";
+        std::cerr << "Usage: stream1090 -s <rate> -u <rate> [-d <device.ini>] [-f <taps file>] [-q] [--multicore] [-v] [-h]\n";
         return 1;
     }
 
@@ -339,6 +346,7 @@ int main(int argc, char** argv) {
 
     // set the verbose flag
     r_vars.verbose = args.verbose;
+    r_vars.multicore = args.multicore;
 
     // ------------------------
     // Sample speed parsing
@@ -413,7 +421,6 @@ int main(int argc, char** argv) {
     }
     return 0;
 }
-
 
 
 

--- a/tests/AsyncMagnitudeReaderTest.cpp
+++ b/tests/AsyncMagnitudeReaderTest.cpp
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "AsyncMagnitudeReader.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+#include <semaphore>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr size_t BlockSize = 4;
+using Block = std::array<float, BlockSize>;
+
+class FiniteReader {
+public:
+    explicit FiniteReader(std::vector<Block> blocks)
+        : m_blocks(std::move(blocks))
+    { }
+
+    bool eof() const {
+        return m_next == m_blocks.size();
+    }
+
+    void readMagnitude(float* out) {
+        std::copy(m_blocks[m_next].begin(), m_blocks[m_next].end(), out);
+        ++m_next;
+    }
+
+private:
+    std::vector<Block> m_blocks;
+    size_t m_next = 0;
+};
+
+class InfiniteReader {
+public:
+    bool eof() const { return false; }
+
+    void readMagnitude(float* out) {
+        std::fill_n(out, BlockSize, 1.0f);
+        if (++m_reads == 3)
+            m_bufferFilled.release();
+    }
+
+    bool waitUntilBufferFilled(std::chrono::milliseconds timeout) {
+        return m_bufferFilled.try_acquire_for(timeout);
+    }
+
+private:
+    size_t m_reads = 0;
+    std::binary_semaphore m_bufferFilled{0};
+};
+
+class BlockingReader {
+public:
+    bool eof() {
+        m_waiting.release();
+        m_stop.acquire();
+        return true;
+    }
+
+    void readMagnitude(float*) { }
+
+    bool waitUntilBlocked(std::chrono::milliseconds timeout) {
+        return m_waiting.try_acquire_for(timeout);
+    }
+
+    void stop() {
+        m_stop.release();
+    }
+
+private:
+    std::binary_semaphore m_waiting{0};
+    std::binary_semaphore m_stop{0};
+};
+
+bool preservesBlockOrder() {
+    const std::vector<Block> expected{
+        Block{1.0f, 2.0f, 3.0f, 4.0f},
+        Block{5.0f, 6.0f, 7.0f, 8.0f},
+        Block{9.0f, 10.0f, 11.0f, 12.0f}
+    };
+    FiniteReader input(expected);
+    AsyncMagnitudeReader<FiniteReader, BlockSize, 2> reader(input);
+
+    std::vector<Block> actual;
+    while (!reader.eof()) {
+        Block block;
+        reader.readMagnitude(block.data());
+        actual.push_back(block);
+    }
+
+    return actual == expected;
+}
+
+bool shutdownUnblocksFullOutputBuffer() {
+    InfiniteReader input;
+    bool bufferFilled = false;
+    {
+        AsyncMagnitudeReader<InfiniteReader, BlockSize, 2> reader(input);
+        bufferFilled = input.waitUntilBufferFilled(std::chrono::seconds(1));
+    }
+    return bufferFilled;
+}
+
+bool stoppingInputUnblocksReader() {
+    BlockingReader input;
+    bool readerBlocked = false;
+    {
+        AsyncMagnitudeReader<BlockingReader, BlockSize, 2> reader(input);
+        readerBlocked = input.waitUntilBlocked(std::chrono::seconds(1));
+        input.stop();
+    }
+    return readerBlocked;
+}
+
+} // namespace
+
+int main() {
+    if (!preservesBlockOrder()) {
+        std::cerr << "async reader changed block order\n";
+        return 1;
+    }
+    if (!shutdownUnblocksFullOutputBuffer()) {
+        std::cerr << "producer did not fill the output buffer\n";
+        return 1;
+    }
+    if (!stoppingInputUnblocksReader()) {
+        std::cerr << "producer did not block while waiting for input\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Hello, another PR that helps on my RPi4, splitting the work between 2 cores instead of 1.


## Summary

- add an opt-in `--multicore` mode for hardware devices
- move ordered IQ conversion, filtering, and magnitude calculation to a preprocessing thread in that mode
- keep the existing single-threaded DSP path as the default and keep standard-input mode synchronous
- add block-order and shutdown tests for the asynchronous reader
- document the new option

## Why

At demanding sample-rate and filtering combinations, IQ preprocessing and demodulation compete for time on the same critical thread. The optional preprocessing thread lets the scheduler place those stages on separate cores while preserving the order required by the stateful FIR pipeline.

The mode is opt-in because it trades additional aggregate CPU work and context switches for more headroom on the demodulation thread.

## Raspberry Pi 4 benchmark

Airspy, 6 Msps input, 24 Msps output, built-in IQ filter enabled; 30-second live-RF runs:

| Metric | Default | `--multicore` |
|---|---:|---:|
| Critical DSP thread | 86.9% | 66.9% |
| Preprocessing thread | - | 24.9% |
| Aggregate task CPU | 0.924 cores | 0.970 cores |
| CPU cycles | baseline | +5.3% |
| Instructions | baseline | +1.6% |
| Cache misses | baseline | +2.7% |
| Context switches | baseline | +36% |

This reduces the critical-thread load by 20 percentage points at a cost of about 5% more aggregate CPU. Message counts are intentionally not compared because the runs used live RF rather than the same captured input.

## Validation

- full Release build on macOS with AppleClang
- 100 consecutive CTest runs on macOS
- Release build with GCC 14 on Raspberry Pi 4
- 100 consecutive CTest runs on Raspberry Pi 4
- Airspy hardware runs for the default and `--multicore` paths
- clean `SIGINT` shutdown verified on Raspberry Pi 4
- ThreadSanitizer run for the asynchronous reader tests
