### PR TITLE
Confirm DF11 replies with interrogator codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,16 @@ if(BUILD_TESTING)
     target_include_directories(crc_error_table_test PRIVATE include)
     target_compile_options(crc_error_table_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME crc_error_table_test COMMAND crc_error_table_test)
+
+    add_executable(icao_cache_test tests/ICAOCacheTest.cpp)
+    target_include_directories(icao_cache_test PRIVATE include)
+    target_compile_options(icao_cache_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME icao_cache_test COMMAND icao_cache_test)
+
+    add_executable(df11_interrogator_test tests/DF11InterrogatorTest.cpp)
+    target_include_directories(df11_interrogator_test PRIVATE include)
+    target_compile_options(df11_interrogator_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME df11_interrogator_test COMMAND df11_interrogator_test)
 endif()
 
 # ------------------------------------------------------------

--- a/README_ADV.md
+++ b/README_ADV.md
@@ -78,6 +78,8 @@ For ```airspy_rx``` this works the same way. However, make sure that your sample
 
 When changing the CRC correction patterns, build and run the `table_gen` target to confirm the declared pattern count. The advanced table uses open addressing to preserve colliding entries. Then run CTest: `crc_error_table_test` verifies that every declared DF17 and DF11 correction remains reachable from its CRC syndrome.
 
+DF11 all-call replies may overlay the CRC parity with a non-zero II/SI interrogator code. Stream1090 accepts these replies for known aircraft. A new ICAO address is added to the cache only after two matching DF11 replies separated in time, so phase duplicates or a single low CRC syndrome cannot seed the cache.
+
 Important: If you want to see the statistics for the whole file and not every 5 seconds. You can enable the a summary at the end by rebuilding stream with after the following cmake call in the build directory
 ```
 cmake ../ --fresh -DEND_STATS=ON -DENABLE_STATS=ON && make

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -324,6 +324,16 @@ public:
 		if (crc == 0) {
 			logStats(Stats::DF11_ICAO_CA_FOUND_GOOD_CRC);
 			return handleDF11ShortMessageWithZeroCRC(streamIndex, frameShort, false);
+		} else if (crc < 80) {
+			// PI is parity overlaid with the interrogator code (II/SI). Require
+			// a second, separate sighting before adding a new address to the cache.
+			const auto icaoWithCA = ModeS::extractICAOWithCA_Short(frameShort);
+			if (!m_cache.findWithCA(icaoWithCA).isValid()
+					&& !m_cache.confirmDF11Candidate(icaoWithCA))
+				return false;
+
+			logStats(Stats::DF11_ICAO_CA_FOUND_GOOD_CRC);
+			return handleDF11ShortMessageWithZeroCRC(streamIndex, frameShort, false);
 		} else  {
 			// ask the 1 bit error correction table for short messages for help
 			const auto fix_op = CRC::df11ErrorTable.lookup(crc);

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -7,12 +7,17 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 
 class ICAOTable {
 public:
 	static constexpr auto TTL_not_trusted { 10 };
 	static constexpr auto TTL_trusted { 30 };
+	// tick() runs at 1 MHz. A DF11 frame lasts 56 us, so 100 us excludes
+	// detections of the same transmission while two seconds keeps the pair local.
+	static constexpr uint32_t DF11CandidateMinTicks { 100 };
+	static constexpr uint32_t DF11CandidateMaxTicks { 2'000'000 };
 	//static constexpr auto ALT_delta_25ft { 80 };
 	static constexpr auto ALT_delta_ft { 2000 };
     // number if bits used for the look up table 
@@ -96,7 +101,25 @@ public:
 		return ((m_table[key].icao & 0xffffffu) == icao) ? Iterator(key) : Iterator();
 	}
 
+	bool confirmDF11Candidate(uint32_t icaoWithCA) noexcept {
+		auto& candidate = m_df11Candidates[df11CandidateIndex(icaoWithCA)];
+		const auto age = m_df11Clock - candidate.firstSeen;
+
+		if (candidate.icaoWithCA != 0 && candidate.icaoWithCA == icaoWithCA) {
+			if (age >= DF11CandidateMinTicks && age <= DF11CandidateMaxTicks) {
+				candidate = DF11Candidate{};
+				return true;
+			}
+			if (age < DF11CandidateMinTicks)
+				return false;
+		}
+
+		candidate = DF11Candidate{icaoWithCA, m_df11Clock};
+		return false;
+	}
+
 	void tick() noexcept {
+		m_df11Clock++;
 		// the counter will wrap around every second exactly once
 		m_time1Mhz = (m_time1Mhz + 1) % 1000000;
 		
@@ -168,6 +191,15 @@ public:
 		return m_msgStatTable[it.key];
 	}
 private:
+	struct DF11Candidate {
+		uint32_t icaoWithCA { 0 };
+		uint64_t firstSeen { 0 };
+	};
+
+	static constexpr size_t df11CandidateIndex(uint32_t icaoWithCA) noexcept {
+		return (icaoWithCA * 0x9e3779b1u) >> 24;
+	}
+
 	void doTickForEntry(uint16_t index) noexcept {
 		auto& entry = m_table[index];
 		if (entry.icao == 0x0)
@@ -196,6 +228,8 @@ private:
 	
 	// runs from 0 to 999 999
 	uint32_t m_time1Mhz { 0 };
+	uint64_t m_df11Clock { 0 };
+	std::array<DF11Candidate, 256> m_df11Candidates{};
 
     // the table with the icao addresses including transponder CA 
 	std::unique_ptr<Entry[]> m_table;

--- a/tests/DF11InterrogatorTest.cpp
+++ b/tests/DF11InterrogatorTest.cpp
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "DemodCore.hpp"
+
+#include <cstdint>
+
+namespace {
+
+struct CapturingHandler {
+    void handleShort(uint64_t, uint64_t frame) {
+        shortCount++;
+        lastShort = frame;
+    }
+
+    void handleLong(uint64_t, const Bits128&) {}
+
+    uint32_t shortCount { 0 };
+    uint64_t lastShort { 0 };
+};
+
+uint64_t makeDF11(uint32_t icao, uint8_t interrogatorCode) {
+    constexpr uint8_t capability = 5;
+    uint64_t frame = (uint64_t(11) << 51)
+        | (uint64_t(capability) << 48)
+        | (uint64_t(icao) << 24);
+    const auto parity = CRC::compute<56>(Bits128(frame)) ^ interrogatorCode;
+    return frame | parity;
+}
+
+void feedFrame(DemodCore<1, CapturingHandler>& demod, uint64_t frame) {
+    for (int bit = 55; bit >= 0; --bit) {
+        uint32_t value[] = { uint32_t((frame >> bit) & 1) };
+        demod.shiftInNewBits(value);
+    }
+
+    for (int bit = 0; bit < 72; ++bit) {
+        uint32_t value[] = { 0 };
+        demod.shiftInNewBits(value);
+    }
+}
+
+} // namespace
+
+int main() {
+    constexpr uint32_t icao = 0xabcdef;
+    const auto first = makeDF11(icao, 1);
+    const auto second = makeDF11(icao, 22);
+    const auto third = makeDF11(icao, 79);
+
+    if (CRC::compute<56>(Bits128(first)) != 1
+            || CRC::compute<56>(Bits128(second)) != 22
+            || CRC::compute<56>(Bits128(third)) != 79)
+        return 1;
+
+    CapturingHandler handler;
+    DemodCore<1, CapturingHandler> demod(handler);
+
+    feedFrame(demod, first);
+    if (handler.shortCount != 0)
+        return 1;
+
+    feedFrame(demod, second);
+    if (handler.shortCount != 0)
+        return 1;
+
+    feedFrame(demod, third);
+    return !(handler.shortCount == 1 && handler.lastShort == third);
+}

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "ICAOCache.hpp"
+
+namespace {
+
+void tick(ICAOTable& table, uint32_t count) {
+    while (count-- > 0)
+        table.tick();
+}
+
+bool confirmsOnlySeparateSightings() {
+    ICAOTable table;
+    constexpr uint32_t icaoWithCA = 0x5abcde1;
+
+    if (table.confirmDF11Candidate(icaoWithCA))
+        return false;
+    if (table.confirmDF11Candidate(icaoWithCA))
+        return false;
+
+    tick(table, ICAOTable::DF11CandidateMinTicks);
+    if (!table.confirmDF11Candidate(icaoWithCA))
+        return false;
+    return !table.confirmDF11Candidate(icaoWithCA);
+}
+
+bool expiresOldSightings() {
+    ICAOTable table;
+    constexpr uint32_t icaoWithCA = 0x3abcdef;
+
+    if (table.confirmDF11Candidate(icaoWithCA))
+        return false;
+    tick(table, ICAOTable::DF11CandidateMaxTicks + 1);
+    return !table.confirmDF11Candidate(icaoWithCA);
+}
+
+bool hashCollisionsCannotConfirmAnotherAddress() {
+    ICAOTable table;
+    constexpr uint32_t first = 0x0100001;
+    uint32_t collision = first + 1;
+
+    while (((first * 0x9e3779b1u) >> 24) != ((collision * 0x9e3779b1u) >> 24))
+        collision++;
+
+    if (table.confirmDF11Candidate(first))
+        return false;
+    tick(table, ICAOTable::DF11CandidateMinTicks);
+    if (table.confirmDF11Candidate(collision))
+        return false;
+    tick(table, ICAOTable::DF11CandidateMinTicks);
+    return !table.confirmDF11Candidate(first);
+}
+
+} // namespace
+
+int main() {
+    return !(confirmsOnlySeparateSightings()
+        && expiresOldSightings()
+        && hashCollisionsCannotConfirmAnotherAddress());
+}


### PR DESCRIPTION
hi, no worries about the pending PR. Please take a look at this one, I think it's an interesting improvement.


## Summary

- recognize valid DF11 replies whose parity is overlaid with a non-zero II/SI interrogator code
- require two temporally separate sightings of the same ICAO+CA before a new address can enter the main cache
- handle low syndromes before the one-bit repair table, where valid interrogator codes can otherwise collide with repair syndromes
- preserve the original PI field in emitted frames
- add cache-level and end-to-end regression tests

## Why

For DF11 all-call replies, a CRC syndrome from 1 through 79 can represent a valid II/SI interrogator code rather than a damaged frame. Treating every non-zero syndrome as an error loses those replies and can prevent Mode-S-only aircraft from entering the ICAO cache.

Accepting every low syndrome immediately would weaken validation and allow a single false candidate to seed that cache. This change keeps low-syndrome candidates separate from the main cache. A new ICAO+CA is admitted only after a matching observation arrives between 100 microseconds and two seconds later. The lower bound excludes phase detections of the same 56-microsecond transmission. Exact-key checks mean candidate-table collisions can only reduce recovery; they cannot confirm a different address.

The candidate table uses 4 KiB and a 64-bit observation clock. Aircraft already present in the cache do not need the extra confirmation.

## Recorded-IQ benchmark

Airspy capture, 6 Msps input, 24 Msps output, built-in IQ filter enabled; one 10-second capture processed once by each build:

| Variant | Messages | Change from current `main` |
|---|---:|---:|
| Current `main` | 6,052 | - |
| Two-sighting confirmation | 6,232 | +180 (+2.97%) |
| Immediate low-syndrome acceptance | 6,278 | +226 (+3.73%) |

The confirmed version retains about 80% of the immediate-acceptance gain without allowing one low syndrome to initialize the cache. Three-run `perf stat` measurements showed no measurable CPU regression; instruction count increased by about 1.4% while task-clock, cycles, and cache misses remained within run-to-run variation.

## Validation

- Release builds with AppleClang and GCC 14
- AddressSanitizer and UndefinedBehaviorSanitizer test run
- 100 consecutive CTest runs on Raspberry Pi
- end-to-end DF11 test with IID values 1, 22, and 79, including the IID 1 / one-bit-repair syndrome collision
- tests for phase separation, candidate expiry, and hash collisions
- deterministic recorded-IQ output verified by SHA-256
