### PR TITLE
Keep README compatible with CMake 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ With stream1090 you proceed as above in the readsb section.
 #### Disable stream1090 statistics
 If you want to run stream1090 as a service, it makes sense to disable the statistics. You can do so by setting the corresponding option for cmake and rebuild the project:
 ```
-cmake ../ --fresh -DENABLE_STATS=OFF && make
+cmake .. -DENABLE_STATS=OFF && cmake --build .
 ```
 
 ## Experimental Features
@@ -282,7 +282,7 @@ If you have an RTL-SDR device and still not happy, you can push things further. 
 
 If you want to use it, there is no need to download anything nor building and such. Stream1090's CMake project will take care of it. Go to the build folder and rebuild with
 ```
-cmake ../ --fresh -DENABLE_RTLSDR_BLOG=1 && make
+cmake .. -DENABLE_RTLSDR_BLOG=1 && cmake --build .
 ``` 
 Check if everything has worked out by running ```./stream1090 -h```. The native device support section should now list ```RTL-SDR Blog (advanced)```.
 


### PR DESCRIPTION
## Summary

- replace `cmake --fresh` in the two rebuild examples with a CMake 3.10-compatible configure command
- use `cmake --build .` instead of invoking `make` directly

## Why

The README declares CMake 3.10 as the minimum version, but `--fresh` was introduced in CMake 3.24. The documented commands therefore fail on otherwise supported CMake versions. Using `cmake --build .` also keeps the examples independent of the selected generator.

## Validation

Tested the exact commit on a Raspberry Pi:

- `cmake .. -DENABLE_STATS=OFF && cmake --build .`: build succeeded; all 3 CTest tests passed
- `cmake .. -DENABLE_RTLSDR_BLOG=1 && cmake --build .`: build succeeded; `stream1090 -h` reported `RTL-SDR Blog (advanced)`
