### PR TITLE
Add optional 12-bit packing for Airspy transfers

### DIFF
--- a/configs/airspy.ini
+++ b/configs/airspy.ini
@@ -18,6 +18,14 @@ linearity_gain = 16
 # or 
 # sensitivity_gain = 5
 
+# Send the 12-bit samples packed instead of padded into 16-bit words. This
+# needs 25% less USB bandwidth (18 MB/s instead of 24 at 6 MSPS) and is
+# lossless, since the ADC is 12-bit. Off by default in libairspy. Enable it
+# if the bus cannot sustain the unpacked rate: on a Raspberry Pi 4 sharing
+# the bus, an Airspy Mini at 6 MSPS delivered 11.08 of 12.00 MSPS unpacked
+# and the full 11.998 with packing on, and the shortfall grew with gain.
+# packing = true
+
 # Optional: manual gain controls. If set, these override
 # linearity_gain and sensitivity_gain.
 # lna_gain = 10

--- a/include/devices/AirspyDevice.hpp
+++ b/include/devices/AirspyDevice.hpp
@@ -46,6 +46,7 @@ private:
         int mixer_gain = 5;
         int vga_gain = 5;
         bool bias_tee = false;
+        bool packing = false;
     };
 
     ShadowState m_state;

--- a/src/devices/AirspyDevice.cpp
+++ b/src/devices/AirspyDevice.cpp
@@ -202,14 +202,29 @@ bool AirspyDevice::applySetting(const std::string& key, const std::string& value
         // sample rate would otherwise pass unnoticed.
         const bool enabled =
             value == "1" || value == "true" || value == "on";
-        if (airspy_set_packing(m_dev, enabled ? 1 : 0) != AIRSPY_SUCCESS) {
+        if (m_state.packing == enabled)
+            return true;
+
+        const int result = airspy_set_packing(m_dev, enabled ? 1 : 0);
+        if (result == AIRSPY_ERROR_BUSY) {
+            // libairspy reallocates the USB transfers when packing changes,
+            // so it refuses while streaming. A reload can therefore reach
+            // this, and it is not a firmware limitation.
+            std::cerr << "[AirspyDevice] packing can only be changed before "
+                         "the device starts streaming; restart to apply"
+                      << std::endl;
+            return false;
+        }
+        if (result != AIRSPY_SUCCESS) {
             std::cerr << "[AirspyDevice] packing not supported by this "
                          "device or firmware; continuing unpacked"
                       << std::endl;
             return false;
         }
         std::cerr << "[AirspyDevice] packing: "
+                  << (m_state.packing ? "on" : "off") << " -> "
                   << (enabled ? "on" : "off") << std::endl;
+        m_state.packing = enabled;
         return true;
     }
     if (key == "bias_tee") {

--- a/src/devices/AirspyDevice.cpp
+++ b/src/devices/AirspyDevice.cpp
@@ -187,6 +187,31 @@ bool AirspyDevice::applySetting(const std::string& key, const std::string& value
     if (key == "lna_gain")         return setLnaGain(std::stoi(value));
     if (key == "mixer_gain")       return setMixerGain(std::stoi(value));
     if (key == "vga_gain")         return setVgaGain(std::stoi(value));
+    if (key == "packing") {
+        // The device can send its 12-bit samples packed instead of padded
+        // into 16-bit words, which is 25% less USB bandwidth. That matters
+        // when the bus cannot sustain the unpacked rate: at 6 MSPS unpacked
+        // needs 24 MB/s, and on a Raspberry Pi sharing the bus with the rest
+        // of a feeder stack this dropped about 8% of the transfers. It is
+        // lossless here, since the ADC is 12-bit and the upper bits are
+        // padding.
+        //
+        // libairspy leaves this off by default and older firmware may not
+        // support it, so a rejected request is reported rather than
+        // swallowed: the caller ignores the return value, and the reduced
+        // sample rate would otherwise pass unnoticed.
+        const bool enabled =
+            value == "1" || value == "true" || value == "on";
+        if (airspy_set_packing(m_dev, enabled ? 1 : 0) != AIRSPY_SUCCESS) {
+            std::cerr << "[AirspyDevice] packing not supported by this "
+                         "device or firmware; continuing unpacked"
+                      << std::endl;
+            return false;
+        }
+        std::cerr << "[AirspyDevice] packing: "
+                  << (enabled ? "on" : "off") << std::endl;
+        return true;
+    }
     if (key == "bias_tee") {
         bool enabled = (value == "1" || value == "true" || value == "on");
         return setBiasTee(enabled);


### PR DESCRIPTION
The Airspy can send its 12-bit samples packed rather than padded into 16-bit words, which needs 25% less USB bandwidth: 18 MB/s instead of 24 at 6 MSPS. It is lossless, since the ADC is 12-bit and the upper bits are padding. `libairspy` leaves it off by default and stream1090 never called `airspy_set_packing`, so this exposes it as an opt-in `packing` key.

## Why

It matters when the bus cannot sustain the unpacked rate. On a Raspberry Pi 4 whose USB is shared with the rest of a feeder stack, an Airspy Mini at 6 MSPS delivered **11.08 of a nominal 12.00 MSPS** unpacked, and the shortfall grew with the gain setting.

Measured with `airspy_rx -r /dev/null` so no decoder is involved, 20 s per point:

| linearity gain | 8 | 14 | 20 | 21 |
| --- | ---: | ---: | ---: | ---: |
| unpacked | 10.05 | 10.02 | 9.99 | 9.96 |
| packed | 11.01 | 11.01 | 11.01 | 11.01 |

Two things change: about 10% more samples arrive, and the delivered rate stops depending on the gain. Inside stream1090 on the same Pi the rate goes from 11.079 to 11.998 MSPS against a nominal 12.000, so the deficit disappears rather than shrinking, and the time the device callback spends waiting for ring buffer space drops to 1.6%.

The gain dependence is worth calling out separately: it silently penalises higher-gain settings, because they receive less data than lower ones. Anyone comparing gain settings on a bandwidth-limited host is measuring the transport as much as the radio.

## Scope

Opt-in, default unchanged. A receiver whose link is not saturated gains nothing: an Airspy R2 on a Mac at 10 MSPS already delivered 19.998 of 20.000 MSPS unpacked, and packing made no difference there.

Older firmware may not support packing, so a rejected request is reported rather than swallowed. `applySetting`’s return value is ignored by the caller, so without the message a user would keep the reduced sample rate with no indication.

## Testing

Built and `ctest` clean on macOS (Apple clang 21) and Debian aarch64 (GCC 14.2). Verified on an Airspy Mini (firmware `v1.0.0-rc10-6`) at 6 MSPS and an Airspy R2 (firmware 2016) at 10 MSPS; the R2 accepts packing too, so the firmware requirement is not recent.