### PR TITLE
Close the device from one thread only

### DIFF
--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -174,7 +174,12 @@ public:
                 // 1) Device health check. Is the device still alive?
                 if (m_device && m_device->lastSignOfLife() > 1000ms) {
                     log("[Stream1090] No samples for 1000ms. Device lost?");
-                    m_device->close();
+                    // Only wake the pipeline here, and leave the device to the
+                    // shutdown path below, which closes it in every case.
+                    // Closing from this thread as well means two threads run
+                    // close() concurrently: both reach rtlsdr_close/airspy_close
+                    // on the same handle and both join the same reader thread.
+                    m_device->shutdownWriter();
                     ProcessSignals::handle_sigint(0);
                     break;
                 }


### PR DESCRIPTION
Fixes the segfault @kx1t reported in [discussion #4](https://github.com/mgrone/stream1090/discussions/4#discussioncomment-17802020).

## What happens

The watchdog closes the device when it decides it is gone:

```cpp
if (m_device && m_device->lastSignOfLife() > 1000ms) {
    log("[Stream1090] No samples for 1000ms. Device lost?");
    m_device->close();
    ProcessSignals::handle_sigint(0);
```

and the shutdown path after the DSP pipeline closes it again:

```cpp
log("[Stream1090] Shutting down device.");
m_device->close();
```

Those run on two different threads with nothing between them. Neither `RtlSdrDevice::close()` nor `AirspyDevice::close()` guards against a second entry: `stop()` reads `m_dev`, calls `rtlsdr_cancel_async`/`airspy_stop_rx` on it and joins the reader thread, then `close()` closes the handle and nulls the pointer. Two threads in that sequence close the same handle twice and join the same `std::thread` twice, which is undefined behaviour on its own.

kx1t’s log shows exactly that ordering:

```
[Stream1090] No samples for 1000ms. Device lost?   <- watchdog close()
[Stream1090] Shutting down device.                 <- shutdown-path close()
rtlsdr_demod_read_reg failed with -4
rtlsdr_write_reg failed with -1
Segmentation fault (core dumped)
```

It only shows up on this path because a normal `SIGINT` leaves the watchdog loop through `shutdownRequested()` without closing anything, so only one thread ever closes.

## The change

The watchdog now only shuts the writer down. `RingBufferAsync::shutdown()` notifies the waiters and `waitForNewBlocks()` returns 0, so the pipeline unwinds exactly as it does on any other exit, and the existing shutdown path performs the single close it already performed everywhere else. One owner, so there is nothing left to serialise.

Making `close()` itself idempotent would be reasonable defence in depth, but it needs a lock or an atomic handle in both devices and I did not want to widen a crash fix into a refactor. Happy to add it if you prefer that shape.

## What I did not do

I have no RTL-SDR here, so I could not reproduce the crash. The diagnosis is from reading the two call sites against kx1t’s log; the reasoning is above so you can check it rather than take my word. What I did verify is that the ordinary paths still work: builds clean, `ctest` unchanged, and a 3 MB stdin replay exits 0 normally.

Note that `-q` is not the cause. It only changes whether the device delivers samples inside the first second; once the watchdog fires, this race is reached regardless of the input flags.