### PR TITLE
Assert the DF-11 contract rather than the frame word

### DIFF
--- a/tests/DF11InterrogatorTest.cpp
+++ b/tests/DF11InterrogatorTest.cpp
@@ -64,5 +64,17 @@ int main() {
         return 1;
 
     feedFrame(demod, third);
-    return !(handler.shortCount == 1 && handler.lastShort == third);
+    if (handler.shortCount != 1)
+        return 1;
+
+    // The interrogator code is xored out of the parity before the frame is
+    // emitted, so a downstream decoder recomputing the CRC sees zero. Assert
+    // the property rather than the resulting word, so the test keeps stating
+    // the contract if the frame layout ever moves.
+    if (CRC::compute<56>(Bits128(handler.lastShort)) != 0)
+        return 1;
+
+    // Everything outside the parity field must be untouched.
+    constexpr uint64_t parityMask = (uint64_t(1) << 24) - 1;
+    return !((handler.lastShort & ~parityMask) == (third & ~parityMask));
 }


### PR DESCRIPTION
`df11_interrogator_test` currently fails on `main`.

```
$ cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build && ctest --test-dir build
The following tests FAILED:
          3 - df11_interrogator_test (Failed)
```

Bisected to a503ce8:

| commit | df11_interrogator_test |
| --- | --- |
| c79c2dd Version | pass |
| 8b3de72 Merge #14 | pass |
| bb0f5d9 12 bit packing | pass |
| **a503ce8 Make sure that the crc of the DF-11 frame is really 0** | **fail** |

Nothing is wrong with the commit. It emits `frameShort ^ crc` so a decoder downstream recomputing the CRC sees zero, which is what the commit message says it is for. The test simply encoded the previous contract:

```cpp
return !(handler.shortCount == 1 && handler.lastShort == third);
```

i.e. the emitted word had to equal the frame that was fed in, interrogator code and all.

This asserts the new promise instead: the emitted frame has a CRC of zero, and every bit outside the parity field is unchanged. Written that way the test states the intent rather than a word, so it keeps holding if the frame layout moves later.

```
100% tests passed, 0 tests failed out of 3
```

Worth noting that tests are opt-in here — `option(BUILD_TESTING "Build tests" OFF)` — so `ctest` reports "No tests were found" unless you pass `-DBUILD_TESTING=ON`, which is presumably how this went unnoticed. I have opened #18 to run them on push and pull request.