### PR TITLE
Build and run the tests on push and pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # Build the way a user would, with both device backends present, and run
+  # the test suite. Tests are opt-in in CMakeLists.txt, so -DBUILD_TESTING=ON
+  # is required or ctest silently finds nothing to run.
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake pkg-config libairspy-dev librtlsdr-dev
+
+      - name: Configure
+        env:
+          CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
+          CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  # The device backends are optional: CMakeLists.txt drops each one when its
+  # library is missing. Nothing else builds that configuration, so it is easy
+  # to break without noticing.
+  build-without-device-backends:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake pkg-config
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
Adds a GitHub Actions workflow that configures, builds and runs `ctest` on every push to `main` and every pull request, with gcc and with clang.

## Why now

`df11_interrogator_test` has been failing on `main` since a503ce8 this afternoon, and nothing surfaced it. A run of this workflow would have flagged it within a few minutes of the push. #17 fixes that test; **this PR should land after it**, otherwise the first CI run is red on arrival.

## The non-obvious bit

Tests are opt-in:

```cmake
option(BUILD_TESTING         "Build tests" OFF)
```

so `ctest` reports `No tests were found` unless `-DBUILD_TESTING=ON` is passed. A workflow that omitted it would build the binary, run no tests and report green, which is worse than having no CI at all. The workflow passes it explicitly.

## Jobs

- **build-and-test** — both backends installed (`libairspy-dev`, `librtlsdr-dev`), Release, build, `ctest --output-on-failure`. Matrix over gcc and clang, `fail-fast: false` so one compiler failing still shows the other.
- **build-without-device-backends** — neither library installed. `CMakeLists.txt` drops each backend when its library is missing, and nothing else exercises that path. Verified locally by hiding both from pkg-config:

  ```
  -- [stream1090] Airspy support disabled (libairspy not found)
  -- [stream1090] RTL-SDR support disabled (no Blog fork, no system librtlsdr)
  [100%] Built target stream1090
  ```

Deliberately kept small: no caching, no sanitizers, no packaging. Those are worth having but they are separate decisions, and a first workflow is easier to judge when it does one thing.

If you would rather not have CI at all, or want it somewhere other than Actions, close this without ceremony — the test fix in #17 stands on its own.