### PR TITLE
Remove merge conflict markers from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles
@@ -18,6 +17,4 @@ CMakeUserPresets.json
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #cmake-build-*
-=======
 build/
->>>>>>> 761b95d (Initial commit)


### PR DESCRIPTION
The file has carried conflict markers since the initial commit:

```
<<<<<<< HEAD
CMakeLists.txt.user
CMakeCache.txt
...
#cmake-build-*
=======
build/
>>>>>>> 761b95d (Initial commit)
```

Both sides were clearly wanted — the CMake artefacts on one and `build/` on the other — so this keeps both and drops the three marker lines.

To be clear about the impact: nothing was broken. git reads those lines as ordinary ignore patterns, they match no file anyone would create, and both lists were already in effect. This is a tidy-up, not a bug fix.

Verified after the change that both still apply:

```
$ git check-ignore -v build/ CMakeCache.txt
.gitignore:20:build/	build/
.gitignore:2:CMakeCache.txt        CMakeCache.txt
```