### PR TITLE
Wake the ring buffer writer as soon as one block is free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ if(BUILD_TESTING)
     target_include_directories(df11_interrogator_test PRIVATE include)
     target_compile_options(df11_interrogator_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME df11_interrogator_test COMMAND df11_interrogator_test)
+
+    add_executable(ring_buffer_test tests/RingBufferTest.cpp)
+    target_include_directories(ring_buffer_test PRIVATE include)
+    target_compile_options(ring_buffer_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME ring_buffer_test COMMAND ring_buffer_test)
 endif()
 
 # ------------------------------------------------------------

--- a/include/RingBuffer.hpp
+++ b/include/RingBuffer.hpp
@@ -145,7 +145,7 @@ public:
         std::unique_lock<std::mutex> lock(m_mutex);
         m_condVar.wait(lock, [&]{
             //std::cerr << "Waiting for desired Blocks " << desiredBlocks << " full "<< m_numFullBlocks << std::endl;
-            return m_shutdown || (NumBlocks - m_numFullBlocks) > desiredBlocks;
+            return m_shutdown || (NumBlocks - m_numFullBlocks) >= desiredBlocks;
         });
         return m_numFullBlocks;
     }

--- a/tests/RingBufferTest.cpp
+++ b/tests/RingBufferTest.cpp
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "RingBuffer.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <future>
+
+namespace {
+
+void require(bool condition) {
+    if (!condition)
+        std::abort();
+}
+
+void testWriterResumesAfterOneBlockIsConsumed() {
+    using Ring = RingBufferAsync<int, 1, 2>;
+
+    Ring ring;
+    Ring::Writer writer(ring);
+    Ring::Reader reader(ring);
+
+    const int initial[] = {1, 2};
+    writer.write(initial, 2);
+
+    auto pendingWrite = std::async(std::launch::async, [&] {
+        const int value = 3;
+        writer.write(&value, 1);
+    });
+
+    require(!reader.eof());
+    reader.process([](const int*) {});
+
+    const auto status = pendingWrite.wait_for(std::chrono::seconds(1));
+    if (status != std::future_status::ready) {
+        reader.process([](const int*) {});
+        pendingWrite.wait();
+    }
+
+    require(status == std::future_status::ready);
+}
+
+} // namespace
+
+int main() {
+    testWriterResumesAfterOneBlockIsConsumed();
+}


### PR DESCRIPTION
`RingBuffer::waitForSpace()` waits for *strictly more* than the requested number of blocks:

```cpp
return m_shutdown || (NumBlocks - m_numFullBlocks) > desiredBlocks;
```

The only caller (`RingBuffer.hpp:241`) asks for one block, so the writer stays parked until **two** blocks are free. In effect one block of the ring is never usable, and the device callback can block while space is actually available — which is exactly the condition the new watchdog warning reports.

Changing the comparison to `>=` lets the writer resume as soon as the space it asked for exists.

### Test

Adds `tests/RingBufferTest.cpp`, registered under `BUILD_TESTING`. It fills a 2-block ring, starts a writer that needs one more block, consumes a single block, and asserts the pending write completes.

Verified against current `main`:

- without the fix: `ring_buffer_test` aborts (exit 134)
- with the fix: passes

Full suite on this branch is green (`ctest`: 4/4).