### PR TITLE
Exit with a failure status when the device never comes up

### DIFF
--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -18,6 +18,7 @@
 #include "devices/IniConfig.hpp"
 #include "devices/DeviceFactory.hpp"
 #include <chrono>
+#include <optional>
 #include <sstream>
 
 
@@ -130,26 +131,26 @@ public:
         }
     }
 
-    void run_async_device(auto& iqPipeline) {
+    bool run_async_device(auto& iqPipeline) {
         RingBuffer ringBuffer;
         Writer writer(ringBuffer);
 
         m_device = DeviceFactory<RawType>::create(m_runtimeVars.deviceType, inputRate, writer);
         if (!m_device) {
             Log::error("Stream1090", "Device instantiation failed.");
-            return;
+            return false;
         }
         Log::info("Stream1090", "Device created.");
 
         if (!setup_device()) {
             Log::error("Stream1090", "Device configuration failed.");
-            return;
+            return false;
         }
         Log::info("Stream1090", "Device successfully configured.");
 
         if (!m_device->start()) {
             Log::error("Stream1090", "Device refuses to start. Aborting.");
-            return;
+            return false;
         }
         Log::info("Stream1090", "Device is running. ");
 
@@ -244,11 +245,11 @@ public:
         }
         Log::info("Stream1090", "Shutdown completed.");
         Log::msg("Stream1090") << "Finished. (" << dur_wct_secs/1000.0 << "s)";
-        std::exit(0);
+        return true;
     }
 
 
-    void run_sync_stdin(auto& iqPipeline) {
+    bool run_sync_stdin(auto& iqPipeline) {
         Log::info("Stream1090", "Reading from stdin");
         auto start_wct = std::chrono::steady_clock::now();
 
@@ -266,20 +267,20 @@ public:
         auto end_wct = std::chrono::steady_clock::now();
         auto dur_wct_secs = std::chrono::duration_cast<std::chrono::milliseconds>(end_wct - start_wct).count();
         Log::msg("Stream1090") << "Finished. (" << dur_wct_secs/1000.0 << "s)";
-        std::exit(0);
+        return true;
     }
 
-    void run() {
+    bool run() {
         // setup pipeline
         auto iqPipeline = IQPipelineSelector<inputRate, outputRate, pipelineOption>().make(m_runtimeVars.filterTaps);
         Log::info("",iqPipeline.toString());
         // for sync read from std in we take a short cut
         if (m_runtimeVars.deviceType == InputDeviceType::STREAM) {
             Log::info("Stream1090", "Sync Stdin Mode");
-            run_sync_stdin(iqPipeline);
+            return run_sync_stdin(iqPipeline);
         } else {
             Log::info("Stream1090", "Async Device Mode");
-            run_async_device(iqPipeline);
+            return run_async_device(iqPipeline);
         }
     }
 
@@ -298,8 +299,12 @@ constexpr bool for_each_in_tuple(const Tuple& t, F&& f) {
     return done;
 }
 
-bool runInstanceFromPresets(const CompileTimeVars& compileTimeVars, const RuntimeVars& runtimeVars) {
-    return for_each_in_tuple(presets, [&](auto const& p) {
+// Returns nothing when no preset matches the requested configuration, and
+// otherwise the outcome of the run: true when the instance ran and shut down
+// normally, false when it gave up (for example because the device never came up).
+std::optional<bool> runInstanceFromPresets(const CompileTimeVars& compileTimeVars, const RuntimeVars& runtimeVars) {
+    std::optional<bool> outcome;
+    for_each_in_tuple(presets, [&](auto const& p) {
         using P = std::decay_t<decltype(p)>;
 
         if (P::RawFormatType::id  == compileTimeVars.rawFormat &&
@@ -307,9 +312,10 @@ bool runInstanceFromPresets(const CompileTimeVars& compileTimeVars, const Runtim
             P::outputRate         == compileTimeVars.outputRate &&
             P::pipelineOption     == compileTimeVars.pipelineOption) 
         {
-            MainInstance<P>(runtimeVars).run();
+            outcome = MainInstance<P>(runtimeVars).run();
             return true;
         }
         return false;
     });
+    return outcome;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -408,11 +408,12 @@ int main(int argc, char** argv) {
     // ------------------------
     // Let's go
     // ------------------------
-    if (!runInstanceFromPresets(c_vars, r_vars)) {
+    const auto outcome = runInstanceFromPresets(c_vars, r_vars);
+    if (!outcome) {
         std::cerr << "[Stream1090] Configuration is not supported: "<< c_vars.inputRate << " -> " << c_vars.outputRate << std::endl;
-        return -1;
+        return 1;
     }
-    return 0;
+    return *outcome ? 0 : 1;
 }
 
 


### PR DESCRIPTION
### The problem

`run_async_device()` handles all three startup failures with a bare `return;`. Control unwinds through `run()` into `runInstanceFromPresets()`, whose lambda returns `true` meaning *a preset matched* — not *the run succeeded*. `main()` then falls through to `return 0`.

Reproduced on current `main` with no dongle attached:

```console
$ ./stream1090 -s 2.4 -u 8 -d configs/rtlsdr.ini
[Stream1090] Opening device failed.
[Stream1090] Device configuration failed.
$ echo $?
0
```

A missing or busy dongle is therefore indistinguishable from a clean shutdown. Service supervisors — systemd `Restart=on-failure`, container restart policies, shell scripts using `set -e` — see success and neither restart nor report it. It also complements the watchdog warning added in 45ea6f6.

### The change

Let `main()` own the exit status:

- `run_async_device()`, `run_sync_stdin()` and `run()` return `bool`
- `runInstanceFromPresets()` returns `std::optional<bool>`: empty means *no preset matched*, otherwise the outcome of the run. This keeps the two failure kinds distinct — the current `bool` conflates them, which is the root of the bug
- `main()` maps a failed run to exit status 1

This also means the success paths `return true` rather than calling `std::exit(0)`, so a normal run unwinds instead of exiting from deep inside the call stack.

That is safe here, and deliberately so rather than incidentally:

- the shutdown block already closes the device explicitly, and `RtlSdrDevice::close()` calls `stop()`, which joins the reader thread, then drops the handle — so by the time the object is destroyed `m_thread` is not joinable and `m_dev` is null
- the watchdog thread is already joined explicitly in the same block
- the only device destructor is the defaulted `virtual ~InputDeviceBase()`; no derived class declares one, so nothing gets closed a second time on the way out (the failure mode #16 addressed)

The failure paths are unaffected by that part: they already unwound and destroyed the device before this change.

Also folds in a one-liner: the unsupported-configuration path returned `-1`, which reaches the shell as 255. It now returns 1.

### Verification

| scenario | before | after |
| --- | --- | --- |
| device open fails (no dongle) | **0** | **1** |
| stdin mode, clean EOF | 0 | 0 |
| unsupported rate pair | 1 | 1 |
| missing config file | 1 | 1 |
| unsupported preset combination | 255 | 1 |

Existing unit tests pass. The stdin success path was checked specifically for the `std::exit(0)` removal: it still exits 0 and still terminates promptly now that destructors run.

One gap worth stating plainly: the **async** success path — `return true` after `close()` and `watchdog.join()` — needs real hardware to exercise, and I ran these checks on a machine with no SDR attached. The reasoning above is from the code, not from a run. I can test it against an RTL-SDR and an Airspy if you would like that confirmed before merging.

### Note on tests

This ships without a new automated test: the failure needs a genuine device-open failure, so it is not unit-testable against the current structure. An integration test is possible — run the binary against `configs/rtlsdr.ini` on a machine with no SDR attached and assert exit 1 — which CI would satisfy, but it would depend on #18 landing first and would be fragile if a runner ever had a device attached. Happy to add it if you would like.
