### PR TITLE
Repair extended squitters by solving for the least confident bits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,11 @@ if(BUILD_TESTING)
     target_include_directories(ring_buffer_test PRIVATE include)
     target_compile_options(ring_buffer_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME ring_buffer_test COMMAND ring_buffer_test)
+
+    add_executable(erasure_repair_test tests/ErasureRepairTest.cpp)
+    target_include_directories(erasure_repair_test PRIVATE include)
+    target_compile_options(erasure_repair_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME erasure_repair_test COMMAND erasure_repair_test)
 endif()
 
 # ------------------------------------------------------------

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -9,6 +9,7 @@
 
 #include "Bits128.hpp"
 #include "CRC.hpp"
+#include "ErasureRepair.hpp"
 #include "CRCErrorTable.hpp"
 #include "ModeS.hpp"
 #include "ICAOCache.hpp"
@@ -36,6 +37,15 @@ public:
 	// This is the main entry function called by the SampleStream. 
 	// NumStreams many new bits are shifted in. The crc's are updated
 	// and the streams are being checked for new messages
+	using ConfidenceFn = float(*)(const void*, uint8_t, size_t);
+
+	/// Installed by SampleStream so a repair can ask for the demodulator's
+	/// per-bit confidence without the demodulation loop having to store it.
+	void setConfidenceSource(const void* ctx, ConfidenceFn fn) noexcept {
+		m_confidenceCtx = ctx;
+		m_confidenceFn = fn;
+	}
+
 	void shiftInNewBits(uint32_t* cmp) {
 		m_shiftRegisters.shiftInNewBits(cmp); 
 		// the streams and crc's are ready
@@ -217,9 +227,85 @@ public:
 					return sendFrameLongAligned(streamIndex, downlinkFormat, crc, toRepair, e);
 				};				
 			}
+			// The address must belong to a trusted aircraft for a repair to be
+			// accepted at all, so test that first. maybeTrusted() is a single
+			// L1-resident load; this runs at every DF17 header position, where a
+			// full cache probe would be a memory stall.
+			const auto icaoBefore = ModeS::extractICAOWithCA_Long(frame);
+			if (m_cache.maybeTrusted(icaoBefore)
+					&& tryErasureRepairLong(streamIndex, downlinkFormat, frame, crc, icaoBefore))
+				return true;
 			logStats(Stats::DF17_REPAIR_FAILED);
 		}
 		return false;
+	}
+
+	/// @brief Repair a damaged extended squitter by solving for which of the
+	/// least confident bits were flipped. Acceptance is the same as the error
+	/// table path: the recovered address must be a trusted aircraft.
+	/// @return returns true if a message has been send to the output
+	bool tryErasureRepairLong(int streamIndex, const uint8_t& downlinkFormat,
+							  const Bits128& frame, CRC::crc_t crc, uint32_t icaoBefore) {
+		if (m_confidenceFn == nullptr)
+			return false;
+
+		// maybeTrusted() can report a stale slot, so confirm against the table
+		const auto before = m_cache.findWithCA(icaoBefore);
+		if (!before.isValid() || !m_cache.isTrusted(before))
+			return false;
+
+		// collect the least confident bits, excluding the DF field
+		constexpr uint8_t SearchLimit = 112 - 5;
+		constexpr int k = ErasureRepair::Candidates;
+		uint8_t candidates[k];
+		float confidences[k];
+		int count = 0;
+
+		for (uint8_t bit = 0; bit < SearchLimit; ++bit) {
+			const float c = m_confidenceFn(m_confidenceCtx, bit, size_t(streamIndex));
+			if (count == k && c >= confidences[k - 1])
+				continue;
+			int j = (count < k) ? count++ : k - 1;
+			for (; j > 0 && confidences[j - 1] > c; --j) {
+				confidences[j] = confidences[j - 1];
+				candidates[j] = candidates[j - 1];
+			}
+			confidences[j] = c;
+			candidates[j] = bit;
+		}
+
+		const auto solution = ErasureRepair::solve(crc, candidates, size_t(count));
+		if (!solution.solved)
+			return false;
+
+		// Real damage is a few bits; a spurious solve over this many
+		// candidates flips about half of them. The weight cap is what pays
+		// for the width of the candidate window.
+		if (__builtin_popcount(solution.mask) > ErasureRepair::MaxWeight)
+			return false;
+
+		Bits128 repaired{ frame };
+		for (int i = 0; i < count; ++i) {
+			if (!((solution.mask >> i) & 1))
+				continue;
+			Bits128 flip(uint64_t(1));
+			flip.shiftLeft(candidates[i]);
+			repaired = repaired ^ flip;
+		}
+
+		// the solve is only as good as the candidate set, so verify
+		if (CRC::compute<112>(repaired) != 0)
+			return false;
+
+		// repairing may have moved the address; it must still be trusted
+		const auto icaoWithCA = ModeS::extractICAOWithCA_Long(repaired);
+		const auto e = m_cache.findWithCA(icaoWithCA);
+		if (!e.isValid() || !m_cache.isTrusted(e))
+			return false;
+
+		logStats(Stats::DF17_REPAIR_SUCCESS);
+		m_cache.markAsTrustedSeen(e);
+		return sendFrameLongAligned(streamIndex, downlinkFormat, crc, repaired, e);
 	}
 
 	/// @brief Handler for long ACAS and Comm-B messages
@@ -365,6 +451,9 @@ public:
 
 
 private:
+	const void* m_confidenceCtx = nullptr;
+	ConfidenceFn m_confidenceFn = nullptr;
+
 
 #if defined(STATS_ENABLED) && STATS_ENABLED
 	Stats::StatsLog m_statsLog;

--- a/include/ErasureRepair.hpp
+++ b/include/ErasureRepair.hpp
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Syndrome-based erasure decoding for the Mode-S CRC-24.
+ *
+ * A frame's syndrome is the XOR of the per-bit syndrome deltas of every bit
+ * that got flipped. So if we can name a small set of candidate error positions
+ * -- the bits the demodulator was least confident about -- recovering the error
+ * pattern becomes a linear system over GF(2) with 24 equations:
+ *
+ *     XOR_{i in S} delta[p_i] = syndrome
+ *
+ * where S is the subset of candidates that were actually wrong. Solving it by
+ * Gaussian elimination generalises the fixed syndrome tables in CRCErrorTable.hpp
+ * from a catalogue of specific burst shapes to arbitrary patterns.
+ *
+ * Safety
+ * ------
+ * A random syndrome is spuriously "solvable" with probability 2^(k-24), where k
+ * is the number of CANDIDATES offered -- note, not the number of errors. That
+ * alone would cap k around 16.
+ *
+ * But a genuine error pattern is a handful of bits, while a spurious solve over
+ * k candidates flips about k/2 of them. Rejecting solutions heavier than
+ * MaxWeight therefore shrinks the accepted set from 2^k to sum_{w<=W} C(k,w),
+ * and the bound becomes
+ *
+ *     sum_{w <= MaxWeight} C(Candidates, w) / 2^24
+ *
+ * which buys enough budget to widen the window instead. That matters because
+ * the bits an interfering signal corrupts are not always the ones the
+ * demodulator was least sure about, so a wider window catches damage a tight
+ * one ranks out of reach.
+ *
+ * For reference DF17ErrorTableExperimental holds ~933 syndromes, a false-hit
+ * rate of 5.6e-5. Points measured against a 60 s Airspy capture:
+ *
+ *     k=16 W=inf   3.9e-3   +491 messages
+ *     k=24 W=5     3.3e-3   +585 messages   <- chosen: more repairs, lower bound
+ *     k=24 W=6     1.1e-2   +624 messages, and the first false repairs appear
+ *
+ * Acceptance is otherwise unchanged from the table path: a repair is only
+ * emitted if the recovered address belongs to an aircraft already trusted from
+ * DF11.
+ */
+#pragma once
+
+#include "CRC.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace ErasureRepair {
+
+inline constexpr size_t MaxFrameBits = 112;
+
+/// Number of least-confident bit positions offered to the solver.
+inline constexpr int Candidates = 24;
+
+/// Reject any solution flipping more than this many bits. This is what bounds
+/// false repairs -- see the safety note above before changing either constant.
+inline constexpr int MaxWeight = 5;
+
+static_assert(Candidates > 0 && Candidates <= 32,
+              "Candidates must fit the 32-bit solution mask");
+static_assert(MaxWeight > 0 && MaxWeight < Candidates,
+              "MaxWeight must actually constrain the solution");
+
+/// delta[i] is the syndrome contribution of flipping frame bit i. Same
+/// recurrence as CRC::delta<i>(), but as a table so the index can be dynamic.
+inline const std::array<CRC::crc_t, MaxFrameBits>& deltaTable() {
+    static const auto table = [] {
+        std::array<CRC::crc_t, MaxFrameBits> t{};
+        CRC::crc_t crc = 0x1;
+        for (size_t i = 0; i < MaxFrameBits; ++i) {
+            t[i] = crc;
+            crc <<= 1;
+            if (crc & (0x1u << 24))
+                crc ^= CRC::polynomial;
+        }
+        return t;
+    }();
+    return table;
+}
+
+struct Result {
+    bool solved = false;
+    uint32_t mask = 0;   ///< bit i set => candidates[i] was flipped
+};
+
+/// Solve for which of @p candidates were flipped, given the frame's syndrome.
+///
+/// Gauss-Jordan over GF(2): each candidate contributes a 24-bit column, we
+/// reduce those into an echelon basis carrying the combination that produced
+/// each pivot, then reduce the syndrome against that basis. If it reduces to
+/// zero the accumulated combination is an error pattern explaining it.
+inline Result solve(CRC::crc_t syndrome, const uint8_t* candidates, size_t count) {
+    Result result;
+    if (count == 0 || count > 32)
+        return result;
+
+    const auto& delta = deltaTable();
+
+    CRC::crc_t pivotValue[24] = {};
+    uint32_t pivotMask[24] = {};
+    bool pivotUsed[24] = {};
+
+    for (size_t i = 0; i < count; ++i) {
+        if (candidates[i] >= MaxFrameBits)
+            return result;
+
+        CRC::crc_t value = delta[candidates[i]];
+        uint32_t mask = (uint32_t(1) << i);
+
+        for (int bit = 23; bit >= 0; --bit) {
+            if (!((value >> bit) & 1))
+                continue;
+            if (!pivotUsed[bit]) {
+                pivotUsed[bit] = true;
+                pivotValue[bit] = value;
+                pivotMask[bit] = mask;
+                value = 0;
+                break;
+            }
+            value ^= pivotValue[bit];
+            mask ^= pivotMask[bit];
+        }
+        // value == 0 here means the column was dependent on earlier ones
+    }
+
+    CRC::crc_t residual = syndrome;
+    uint32_t combination = 0;
+    for (int bit = 23; bit >= 0; --bit) {
+        if (!((residual >> bit) & 1))
+            continue;
+        if (!pivotUsed[bit])
+            return result;      // syndrome lies outside the span
+        residual ^= pivotValue[bit];
+        combination ^= pivotMask[bit];
+    }
+
+    if (residual != 0)
+        return result;
+
+    result.solved = true;
+    result.mask = combination;
+    return result;
+}
+
+} // namespace ErasureRepair

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -132,9 +132,24 @@ public:
 		doTickForEntry(m_time1Mhz);
 	}
 
+	/// Membership test against an 8 KB bitmap mirroring "this slot currently
+	/// holds a trusted entry". The table itself is 65536 entries of 8 bytes, so
+	/// a probe is an L2/DRAM access; callers that test addresses at demodulation
+	/// rate need a filter that stays in L1.
+	///
+	/// Conservative by construction: markAsTrustedSeen() sets the bit
+	/// immediately, so it is never clear for a trusted entry. A stale set bit is
+	/// harmless because callers still confirm with findWithCA(), and the tick
+	/// sweep clears it within one pass over the table.
+	bool maybeTrusted(uint32_t icaoWithCA) const noexcept {
+		const auto key = icaoWithCA & HashMask;
+		return (m_trustedBits[key >> 6] >> (key & 63)) & 0x1;
+	}
+
 	void markAsTrustedSeen(const Iterator& entry) noexcept {
 		m_table[entry.key].ttl_trusted = TTL_trusted;
 		m_table[entry.key].ttl = TTL_not_trusted;
+		setTrustedBit(entry.key);
 	}
 
 	void markAsSeen(const Iterator& entry, uint16_t ttl = TTL_not_trusted) noexcept {
@@ -200,6 +215,16 @@ private:
 		return (icaoWithCA * 0x9e3779b1u) >> 24;
 	}
 
+	void setTrustedBit(uint32_t key) noexcept {
+		m_trustedBits[key >> 6] |= (uint64_t(1) << (key & 63));
+	}
+
+	void clearTrustedBit(uint32_t key) noexcept {
+		m_trustedBits[key >> 6] &= ~(uint64_t(1) << (key & 63));
+	}
+
+	std::array<uint64_t, Size / 64> m_trustedBits{};
+
 	void doTickForEntry(uint16_t index) noexcept {
 		auto& entry = m_table[index];
 		if (entry.icao == 0x0)
@@ -214,6 +239,12 @@ private:
 		} else {
 			doResetEntry(index);	
 		}
+
+		// keep the trusted-membership filter in step with the entry
+		if (m_table[index].ttl > 0 && m_table[index].ttl_trusted > 0)
+			setTrustedBit(index);
+		else
+			clearTrustedBit(index);
 	}
 
 	void doResetEntry(uint16_t index) noexcept {

--- a/include/SampleStream.hpp
+++ b/include/SampleStream.hpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <memory>
 #include <cstring>
+#include <cmath>
 
 #include "DemodCore.hpp"
 #include "Sampler.hpp"
@@ -126,6 +127,22 @@ public:
     template<typename InputReaderType, MessageHandler Handler>
     void read(InputReaderType& inputReader, Handler& messageHandler);
 
+    /// Recompute the demodulator's confidence in a single frame bit, straight
+    /// from the retained sample ring. The demodulation loop deliberately stores
+    /// nothing: this is only ever called for a frame that already matched a
+    /// trusted address, a few dozen times a second, so recomputing is far
+    /// cheaper than keeping a per-bit history for every stream.
+    float confidenceAt(uint8_t frameBit, size_t stream) const noexcept {
+        // frame bit f was shifted in (16 + f) bit periods ago; see
+        // ShiftRegisters::extractAlignedFrameLong for the 16 bit alignment
+        const size_t delay = (size_t(16) + frameBit) * Sampler::NumStreams;
+        const auto offsetInBlock = size_t(m_demodPos - m_sampleRingBuffer.readPos());
+        const float first  = m_sampleRingBuffer.lookBack(delay - stream, offsetInBlock);
+        const float second = m_sampleRingBuffer.lookBack(delay - stream - (Sampler::NumStreams >> 1),
+                                                        offsetInBlock);
+        return std::fabs(first - second);
+    }
+
     uint8_t getRSSI() const noexcept {
         // we are 128 bits behind and are looking for the preamble pulse
         constexpr size_t bitDelay     = 128 - 8;
@@ -163,6 +180,9 @@ template<typename InputReaderType, MessageHandler Handler>
 inline void SampleStream<Sampler>::read(InputReaderType& inputReader, Handler& messageHandler) {  
     // the core logic for message recognition
     DemodCore<Sampler::NumStreams, Handler> demodCore(messageHandler);
+    demodCore.setConfidenceSource(this, [](const void* ctx, uint8_t bit, size_t stream) -> float {
+        return static_cast<const SampleStream<Sampler>*>(ctx)->confidenceAt(bit, stream);
+    });
 
      // the main loop for reading the stream
     while (!inputReader.eof()) {

--- a/tests/ErasureRepairTest.cpp
+++ b/tests/ErasureRepairTest.cpp
@@ -1,0 +1,193 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "ErasureRepair.hpp"
+#include "ICAOCache.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <random>
+#include <vector>
+
+namespace {
+
+std::mt19937_64 rng(20260729);
+
+// A frame whose CRC-24 is zero, i.e. a well formed extended squitter.
+Bits128 makeValidFrame() {
+    Bits128 frame(rng(), rng());
+    frame.low() &= ~uint64_t(0xFFFFFF);
+    frame.low() |= (CRC::compute<112>(frame) & 0xFFFFFF);
+    return frame;
+}
+
+void flipBit(Bits128& frame, uint8_t index) {
+    Bits128 one(uint64_t(1));
+    one.shiftLeft(index);
+    frame = frame ^ one;
+}
+
+// The runtime table must agree with the compile time deltas it mirrors.
+bool deltaTableMatchesCRC() {
+    const auto& delta = ErasureRepair::deltaTable();
+    return delta[0] == CRC::delta<0>()
+        && delta[1] == CRC::delta<1>()
+        && delta[55] == CRC::delta<55>()
+        && delta[111] == CRC::delta<111>();
+}
+
+// Errors placed inside the candidate set must be recovered exactly.
+bool recoversErrorsInsideCandidateSet() {
+    for (int errors = 1; errors <= 12; ++errors) {
+        for (int trial = 0; trial < 200; ++trial) {
+            Bits128 frame = makeValidFrame();
+
+            std::vector<uint8_t> candidates(ErasureRepair::MaxFrameBits);
+            std::iota(candidates.begin(), candidates.end(), uint8_t(0));
+            std::shuffle(candidates.begin(), candidates.end(), rng);
+            candidates.resize(ErasureRepair::Candidates);
+            if (errors > int(candidates.size()))
+                continue;
+
+            uint32_t expected = 0;
+            for (int e = 0; e < errors; ++e) {
+                flipBit(frame, candidates[e]);
+                expected |= (uint32_t(1) << e);
+            }
+
+            const auto result = ErasureRepair::solve(CRC::compute<112>(frame),
+                                                     candidates.data(), candidates.size());
+            if (!result.solved || result.mask != expected)
+                return false;
+
+            // applying the recovered pattern must clear the CRC
+            for (size_t i = 0; i < candidates.size(); ++i)
+                if ((result.mask >> i) & 1)
+                    flipBit(frame, candidates[i]);
+            if (CRC::compute<112>(frame) != 0)
+                return false;
+        }
+    }
+    return true;
+}
+
+// An undamaged frame has a zero syndrome and needs no flips.
+bool leavesCleanFramesAlone() {
+    std::vector<uint8_t> candidates(ErasureRepair::Candidates);
+    std::iota(candidates.begin(), candidates.end(), uint8_t(0));
+    for (int trial = 0; trial < 200; ++trial) {
+        const auto frame = makeValidFrame();
+        const auto result = ErasureRepair::solve(CRC::compute<112>(frame),
+                                                 candidates.data(), candidates.size());
+        if (!result.solved || result.mask != 0)
+            return false;
+    }
+    return true;
+}
+
+// The spurious-solve rate is what bounds false repairs, so pin it: offering k
+// candidates must accept a random syndrome with probability near 2^(k-24).
+bool spuriousSolveRateMatchesTheory() {
+    constexpr int k = 12;
+    constexpr int trials = 200000;
+
+    std::vector<uint8_t> candidates(ErasureRepair::MaxFrameBits);
+    std::iota(candidates.begin(), candidates.end(), uint8_t(0));
+    std::shuffle(candidates.begin(), candidates.end(), rng);
+    candidates.resize(k);
+
+    int solved = 0;
+    for (int i = 0; i < trials; ++i) {
+        const CRC::crc_t syndrome = CRC::crc_t(rng() & 0xFFFFFF);
+        if (ErasureRepair::solve(syndrome, candidates.data(), candidates.size()).solved)
+            solved++;
+    }
+
+    const double measured = double(solved) / trials;
+    const double expected = 1.0 / double(1u << (24 - k));
+    // generous band; this is a guard against the rate changing by orders of
+    // magnitude, not a distributional test
+    return measured > expected * 0.5 && measured < expected * 2.0;
+}
+
+// The trusted-membership filter must never be clear for a trusted entry,
+// otherwise a repair that should be accepted is silently dropped.
+bool trustedFilterNeverMissesATrustedEntry() {
+    ICAOTable table;
+
+    for (uint32_t i = 0; i < 500; ++i) {
+        const uint32_t icaoWithCA = 0x5000000u | (i * 7919u);
+        const auto entry = table.insertWithCA(icaoWithCA);
+        table.markAsTrustedSeen(entry);
+
+        if (!table.maybeTrusted(icaoWithCA))
+            return false;
+        if (!table.isTrusted(table.findWithCA(icaoWithCA)))
+            return false;
+    }
+    return true;
+}
+
+// And it must actually reject: a table with nothing trusted rejects everything.
+bool trustedFilterRejectsUnknownAddresses() {
+    ICAOTable table;
+    int accepted = 0;
+    for (uint32_t i = 0; i < 20000; ++i)
+        if (table.maybeTrusted(0x4000000u | (i * 104729u)))
+            accepted++;
+    return accepted == 0;
+}
+
+// The shipped configuration accepts a repair only if the solution is also
+// light enough. That combined rate -- not the raw solve rate -- is what bounds
+// false repairs in production, so pin it against the closed form.
+bool weightCappedAcceptanceMatchesTheory() {
+    constexpr int k = ErasureRepair::Candidates;
+    constexpr int w = ErasureRepair::MaxWeight;
+    constexpr int trials = 400000;
+
+    std::vector<uint8_t> candidates(ErasureRepair::MaxFrameBits);
+    std::iota(candidates.begin(), candidates.end(), uint8_t(0));
+    std::shuffle(candidates.begin(), candidates.end(), rng);
+    candidates.resize(k);
+
+    int accepted = 0;
+    for (int i = 0; i < trials; ++i) {
+        const CRC::crc_t syndrome = CRC::crc_t(rng() & 0xFFFFFF);
+        const auto r = ErasureRepair::solve(syndrome, candidates.data(), candidates.size());
+        if (r.solved && __builtin_popcount(r.mask) <= w)
+            accepted++;
+    }
+
+    // sum_{i<=w} C(k,i) / 2^24
+    double ways = 0.0;
+    for (int i = 0; i <= w; ++i) {
+        double c = 1.0;
+        for (int j = 0; j < i; ++j)
+            c = c * (k - j) / (j + 1);
+        ways += c;
+    }
+    const double expected = ways / double(1u << 24);
+    const double measured = double(accepted) / trials;
+    return measured > expected * 0.5 && measured < expected * 2.0;
+}
+
+} // namespace
+
+int main() {
+    if (!deltaTableMatchesCRC())
+        return 1;
+    if (!recoversErrorsInsideCandidateSet())
+        return 1;
+    if (!leavesCleanFramesAlone())
+        return 1;
+    if (!spuriousSolveRateMatchesTheory())
+        return 1;
+    if (!weightCappedAcceptanceMatchesTheory())
+        return 1;
+    if (!trustedFilterNeverMissesATrustedEntry())
+        return 1;
+    if (!trustedFilterRejectsUnknownAddresses())
+        return 1;
+    return 0;
+}


### PR DESCRIPTION
### The idea

`DF17ErrorTableExperimental` can only repair damage whose *shape* it catalogues — around 933 syndromes covering a few burst patterns spanning at most three bits. Everything else is dropped, including cases where the demodulator knew exactly which bits it was unsure about.

That information is recoverable. The CRC-24 syndrome is the XOR of the per-bit syndrome deltas of every flipped bit, so given a candidate set of error positions, the error pattern is a linear system over GF(2) with 24 equations:

```
XOR_{i in S} delta[p_i] = syndrome
```

Offering the *least confident* bits as candidates and solving by Gaussian elimination generalises the table from fixed shapes to arbitrary patterns, at no memory cost.

### Results

Measured against a 60 s Airspy capture (6 Msps, gain 20, busy afternoon), replayed through stdin so runs are deterministic:

| | baseline | this PR | delta |
| --- | --- | --- | --- |
| total messages | 31,267 | 31,852 | **+585 (+1.87%)** |
| DF17 | 4,958 | 5,538 | **+580 (+11.7%)** |
| messages lost | — | 0 | |
| CPU, Pi 4 | 68.4 s | 72.0 s | **+5.4%** |

### What bounds false repairs

Offering k candidates makes a random syndrome solvable with probability `2^(k-24)`. That alone would cap k around 16.

But genuine damage is a handful of bits, while a spurious solve over k candidates flips about half of them. Rejecting solutions heavier than `MaxWeight` shrinks the accepted set from `2^k` to `sum_{w<=W} C(k,w)`, which buys enough budget to **widen** the window instead. That is worth doing because the bits an interfering signal corrupts are not always the ones the demodulator was least sure about, so a wider window reaches damage a tight one ranks out of range.

The shipped point is k=24, W=5: bound `3.3e-3`, *below* the `3.9e-3` of an uncapped k=16, while repairing 19% more frames.

### Are the extra frames real?

Acceptance already requires the recovered address to be a trusted aircraft, so "the ICAO is known" is circular and proves nothing.

The discriminator used instead is the **DF17 typecode**. A spurious solve produces a frame that is CRC-consistent and address-matching but whose 56-bit ME field is essentially arbitrary, so roughly 35% of false repairs should land on an invalid or reserved typecode. Real traffic sits at 0%.

Of the 276 frames this adds, **0 have an invalid typecode**, and the typecode mix tracks the baseline closely. Sweeping the two parameters shows the bound is an accurate predictor of where trouble starts:

| k | W | added | lost | invalid typecodes | bound | vs shipped table config |
| --- | --- | --- | --- | --- | --- | --- |
| 16 | none | 227 | 0 | 0/226 | 3.9e-3 | |
| 20 | 5 | 260 | 0 | 0/260 | 1.3e-3 | 3.0x safer |
| **24** | **5** | **276** | **0** | **0/276** | **3.3e-3** | **1.2x safer** |
| 26 | 5 | 280 | 1 | 0/280 | 5.0e-3 | 1.3x riskier |
| 24 | 6 | 301 | 1 | 1/300 | 1.1e-2 | 2.9x riskier |

The first false repair appears at exactly the point the bound goes meaningfully over budget.

**Worth stating plainly:** k=24/W=5 is not a strict superset of an uncapped k=16. Against that configuration it keeps 215 frames, loses 12 — genuine repairs of weight >5 that the cap now rejects — and gains 61, for a net +49 unique frames. Accepting the union of both regions would recover those 12 but costs ~7.2e-3, 1.8x over budget, so it is not free.

### Why the CPU cost is what it is

Two things had to be avoided, and neither is visible on a fast desktop — on Apple Silicon the whole feature costs ~1.4% and all of this is invisible.

**Confidence is not stored.** Keeping a per-bit confidence history for every stream costs ~19% CPU on a Pi 4; the demodulation loop is the hottest code in the program and doubling its per-bit work is roughly proportional. `SampleStream::confidenceAt()` instead recomputes a bit's confidence from the retained sample ring on demand via the same `lookBack()` the RSSI path already uses. Repairs run a few dozen times a second, so recomputing is far cheaper than storing. Trade-off: a few frames near block boundaries cannot reach their history.

**The trusted-address check needed a filter.** It must run at every DF17 header position — roughly 2.25M times a second — and `ICAOTable` is 65536 entries of 8 bytes, so probing it directly is an L2/DRAM stall each time. `ICAOTable` now also maintains an 8 KB bitmap of which slots hold a trusted entry. Because it is indexed by the same direct-mapped key it is **exact rather than approximate**: no hash false positives beyond what the table itself has. It stays in L1 and rejects ~99.5% of candidates before the table is touched.

The bitmap is conservative by construction: `markAsTrustedSeen()` sets the bit immediately so it can never be falsely clear, and a stale set bit is harmless because callers still confirm with `findWithCA()`. The tick sweep re-derives it within one pass over the table, so it self-heals.

Together these took the cost from +19% to +5.4%. Both are behaviour-neutral — output is byte-identical with and without them.

### Tests

`tests/ErasureRepairTest.cpp` covers:

- the runtime delta table agrees with the compile-time `CRC::delta<>()`
- exact recovery of 1..12 errors placed inside the candidate set, and that applying the recovered pattern clears the CRC
- clean frames are left alone
- the raw solve rate matches `2^(k-24)`
- the weight-capped acceptance rate matches `sum_{w<=W} C(k,w) / 2^24` — this is the bound production actually relies on, so it is pinned against the closed form
- the trusted bitmap never misses a trusted entry, and rejects unknown addresses

Full suite passes (5/5).

### Independent validation on a second capture

Since the numbers above all come from one recording, I took a second, longer one the following day (150 s, same receiver, different traffic) and re-ran without changing anything:

| | baseline | this PR | delta |
| --- | --- | --- | --- |
| total messages | 74,619 | 75,892 | **+1,273 (+1.71%)** |
| DF17 | 13,269 | 14,529 | **+1,260 (+9.5%)** |
| DF17 invalid typecodes | 0/13,269 | **0/14,530** | |
| AP-frame reserved flight-status | 3/26,980 | 3/26,982 | unchanged |

The gain reproduces (+1.71% / +9.5% versus +1.87% / +11.7%) on data the parameters were not tuned against, with zero false repairs among the 1,260 added frames. The AP-overlaid classes are untouched by this change and their small intrinsic anomaly rate is identical before and after, confirming nothing leaks into them.

### Caveats

The evidence is two captures from one receiver. The decode gain should be robust, but the exact point where false repairs appear will move with traffic density and signal conditions, so k=24/W=5 is chosen with margin rather than tuned to the edge. Happy to re-run against other captures if you have them, or to make the two constants configurable.

I also have the raw capture and the analysis scripts if you would like to reproduce any of this.
