### PR TITLE
Add a 6 Msps filter variant with more weight in the centre taps

### DIFF
--- a/custom_filters/EU_enrico_6_24_centre115.txt
+++ b/custom_filters/EU_enrico_6_24_centre115.txt
@@ -1,0 +1,56 @@
+# Variant of EU_mgrone_6_12 (the "sawbird") with more weight in the centre tap group.
+#
+# Derived by hand, not by filter_opt.py: the three centre taps were scaled by
+# 1.15 and the whole filter renormalised. Nothing else was changed.
+#
+#   centre taps 6,7,8 : +5.2%   (0.1741/0.2755/0.1741 -> 0.1830/0.2898/0.1830)
+#   outer taps        : -8.6%
+#   energy in centre  : 62.4% -> 65.6%
+#   -3 dB bandwidth   : 0.294 MHz -> 0.310 MHz
+#
+# Rationale: the bit decision compares two samples half a chip (0.5 us) apart, so
+# a more compact impulse response preserves that contrast, while the wings still
+# provide out-of-band rejection. This trades a little noise rejection for a
+# little less smearing across the half-chip boundary. It is the same reason a
+# textbook matched filter does poorly here despite maximising SNR - measured at
+# 28436 messages versus 31852 for the sawbird on the capture below.
+#
+# Measured with -s 6 -u 24 -q on Airspy Mini captures (Ferrara, IT), replayed
+# from file so runs are deterministic:
+#
+#                     60 s capture        150 s capture (held out)
+#   sawbird           31852               75892
+#   this filter       31911  (+59)        76173  (+281, +0.37%)
+#
+# The gain is LARGER on the held-out capture than on the one used to find it,
+# and it appears across every downlink format (DF11 +123, DF17 +85,
+# DF0/4/5/16/20/21 +74), which is what a genuine front-end improvement should
+# look like rather than a decode-path artefact.
+#
+# CAVEAT: tuned on one receiver. The optimum trade between noise rejection and
+# half-chip smearing depends on the local noise and interference environment,
+# so the direction may generalise while this exact scaling may not. Worth
+# measuring against the built-in filter on your own site before adopting.
+#
+# A second caveat worth recording: an 8-parameter local search over the same
+# taps scored BETTER than this on the 15 s slice it was tuned on (+69) and worse
+# on held-out data (+64 vs +281). filter_opt.py optimises 7-9 gain points
+# against a single capture, which is the same regime - results from it are worth
+# validating against a capture from a different day.
+#
+# Best taps:
+0.005794326709982184
+0.029460341832063187
+0.047685765392198223
+0.034963499118780751
+0.0028456999719045886
+0.051323175702354083
+0.18304253511798252
+0.28976931230946895
+0.18304253511798252
+0.051323175702354083
+0.0028456999719045886
+0.034963499118780751
+0.047685765392198223
+0.029460341832063187
+0.005794326709982184


### PR DESCRIPTION
Adds one file under `custom_filters/`. Nothing else changes, and nothing is enabled by default.

### What it is

The shipped `EU_mgrone_6_12` sawbird with its three centre taps scaled by 1.15 and the filter renormalised:

| | sawbird | this variant |
| --- | --- | --- |
| centre taps 6,7,8 | 0.1741 / 0.2755 / 0.1741 | 0.1830 / 0.2898 / 0.1830 (+5.2%) |
| outer taps | — | −8.6% |
| energy in the centre | 62.4% | 65.6% |
| −3 dB bandwidth | 0.294 MHz | 0.310 MHz |

### Measurements

`-s 6 -u 24`, Airspy Mini captures replayed from file so runs are deterministic. The 150 s capture was recorded a day later and was not used to find the filter:

| | 60 s capture | 150 s capture (held out) |
| --- | --- | --- |
| sawbird | 31,852 | 75,892 |
| this variant | 31,911 (+59) | **76,173 (+281, +0.37%)** |

Two things suggest this is real rather than a fit to one recording. The gain is **larger** on the held-out capture than on the one used to find it, which is the opposite of what overfitting does. And it appears across every downlink format — DF11 +123, DF17 +85, DF0/4/5/16/20/21 +74 — rather than only the formats the decoder repairs, which is what a genuine front-end improvement should look like.

### Why more weight in the centre helps

The bit decision compares two samples half a chip (0.5 µs) apart, so a more compact impulse response preserves that contrast, while the wings still provide out-of-band rejection. Shifting weight inward trades a little noise rejection for a little less smearing across the half-chip boundary.

This is also why a textbook matched filter does poorly here despite maximising SNR — I measured a 3-tap boxcar (matched to the 0.5 µs pulse) at 28,436 messages against the sawbird's 31,852 on the same capture. Maximising SNR blurs precisely the contrast the demodulator measures.

For what it's worth, bandwidth alone does not predict performance at all: the sawbird and a 15-tap Hann window have nearly identical −3 dB points (0.294 vs 0.31 MHz) and differ by a factor of 45 in output (31,852 vs 693). Compactness of the impulse response is what matters.

### Why `custom_filters/` and not a new default

I have measurements from one receiver. The optimum trade between noise rejection and half-chip smearing depends on the local noise and interference environment, so I would expect the *direction* to generalise and this exact 5% scaling not to. Changing the default for everyone on that basis seemed wrong; this way it can be measured per site with `-f`.

### A note on `filter_opt.py` that may be worth more than the filter

While checking whether the shape could be improved further, I ran an 8-parameter local search over the taps against a 15 s slice, then validated it:

| | slice it was tuned on | full 60 s | 150 s held out |
| --- | --- | --- | --- |
| sawbird | 7,929 | 31,852 | 75,892 |
| centre ×1.15 (1 parameter) | 7,979 (+50) | 31,911 (+59) | **76,173 (+281)** |
| 8-parameter search | **7,998 (+69)** | 31,889 (+37) | 75,956 (+64) |

The multi-parameter search won on the data it was tuned on and lost everywhere else; the single-parameter change generalised roughly four times better. `filter_opt.py` optimises 7–9 gain points by differential evolution against a single capture, which is the same regime, so its output is probably worth validating against a capture from a different day before adopting. That is not a criticism of the tool — it found the sawbird, which beats every textbook filter I tried by a wide margin — just a caution about how far to push it on one recording.

Happy to drop this if you would rather not carry another tap file, or to re-run any of the numbers.
