### PR TITLE
Recover confirmed first frames and colliding ICAO entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,11 @@ if(BUILD_TESTING)
     target_compile_options(df11_interrogator_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME df11_interrogator_test COMMAND df11_interrogator_test)
 
+    add_executable(df17_first_frame_test tests/DF17FirstFrameTest.cpp)
+    target_include_directories(df17_first_frame_test PRIVATE include)
+    target_compile_options(df17_first_frame_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME df17_first_frame_test COMMAND df17_first_frame_test)
+
     add_executable(ring_buffer_test tests/RingBufferTest.cpp)
     target_include_directories(ring_buffer_test PRIVATE include)
     target_compile_options(ring_buffer_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})

--- a/README.md
+++ b/README.md
@@ -186,15 +186,29 @@ Stream1090 comes with a single filter for each sample rate combination. These ha
 
 ### Valid-message recovery
 
-A first CRC-clean extended squitter from a new ICAO address is held as an
-untrusted candidate. A second CRC-clean sighting at least 100 microseconds later
-confirms the address and releases both frames with their original timestamps.
-An isolated CRC collision therefore cannot create output or authorize repaired
-and address-parity messages.
+A first CRC-clean extended squitter from a new ICAO address seeds the cache as
+before but is also held as a recovery candidate. A second CRC-clean sighting
+between 100 microseconds and two seconds later releases both frames with their
+original timestamps. An isolated CRC collision therefore cannot itself create
+output, while cache trust retains the existing behavior.
 
 The ICAO cache also keeps two aircraft per hash set, preventing an active
 aircraft from being displaced immediately by another ICAO address with the same
 low 16 bits.
+
+Offline replays of three Airspy 6 Msps captures, demodulated at 24 MHz with the
+built-in FIR, produced the following results against main at `ce230ac`:
+
+| Capture | `origin/main` | Confirmed recovery | Difference |
+| --- | ---: | ---: | ---: |
+| 59.8 seconds | 31,852 | 31,940 | +88 (+0.276%) |
+| 89.8 seconds | 56,929 | 56,961 | +32 (+0.056%) |
+| 145.9 seconds | 75,892 | 76,067 | +175 (+0.231%) |
+
+None of the added explicit-address frames introduced an ICAO seen only once in
+the candidate output. Releasing a held frame preserves its original timestamp,
+so output timestamps can arrive out of order by up to the two-second
+confirmation window.
 
 
 ## Stack Integration

--- a/README.md
+++ b/README.md
@@ -186,16 +186,15 @@ Stream1090 comes with a single filter for each sample rate combination. These ha
 
 ### Valid-message recovery
 
-CRC-clean extended squitters are emitted on their first sighting instead of
-being used only to seed the ICAO cache. The cache keeps two aircraft per hash
-set, preventing an active aircraft from being displaced immediately by another
-ICAO address with the same low 16 bits.
+A first CRC-clean extended squitter from a new ICAO address is held as an
+untrusted candidate. A second CRC-clean sighting at least 100 microseconds later
+confirms the address and releases both frames with their original timestamps.
+An isolated CRC collision therefore cannot create output or authorize repaired
+and address-parity messages.
 
-Offline replay of two Airspy 6 Msps captures, demodulated at 24 MHz with the
-built-in FIR, increased emitted frames from 31,852 to 31,928 over 59.8 seconds
-(+0.24%) and from 75,892 to 76,061 over 145.9 seconds (+0.22%). These counts
-measure frames accepted by Stream1090's existing CRC and trusted-aircraft gates;
-they are not independently labelled RF ground truth.
+The ICAO cache also keeps two aircraft per hash set, preventing an active
+aircraft from being displaced immediately by another ICAO address with the same
+low 16 bits.
 
 
 ## Stack Integration

--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ To enable filtering use
 ```
 Stream1090 comes with a single filter for each sample rate combination. These have been optimized for a set of pre-recorded sample data provided by people from around the world with different setups.
 
+### Valid-message recovery
+
+CRC-clean extended squitters are emitted on their first sighting instead of
+being used only to seed the ICAO cache. The cache keeps two aircraft per hash
+set, preventing an active aircraft from being displaced immediately by another
+ICAO address with the same low 16 bits.
+
+Offline replay of two Airspy 6 Msps captures, demodulated at 24 MHz with the
+built-in FIR, increased emitted frames from 31,852 to 31,928 over 59.8 seconds
+(+0.24%) and from 75,892 to 76,061 over 145.9 seconds (+0.22%). These counts
+measure frames accepted by Stream1090's existing CRC and trusted-aircraft gates;
+they are not independently labelled RF ground truth.
+
 
 ## Stack Integration
 In order to utilize the output of Stream1090, we will send it to a decoder like readsb or dump1090-fa via TCP. This has one big advantage: You do not have to modify anything in the remaining stack.

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -14,6 +14,7 @@
 #include "ModeS.hpp"
 #include "ICAOCache.hpp"
 #include "Stats.hpp"
+#include <array>
 #include <bit>
 #include <cmath>
 #include "ShiftRegisters.hpp"
@@ -198,19 +199,32 @@ public:
 			logStats(Stats::DF17_GOOD_MESSAGE);
 			// get the address including the CA field
 			const auto icaoWithCA = ModeS::extractICAOWithCA_Long(frame);
-			const auto e = m_cache.findWithCA(icaoWithCA);
-			
-			// if we know this plane
-			if (e.isValid()) {
-				m_cache.markAsTrustedSeen(e);
-				// and send the 112 bit message to the output
-				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
-			} else {
-				const auto inserted = m_cache.insertWithCA(icaoWithCA);
-				m_cache.markAsTrustedSeen(inserted);
-				return sendFrameLongAligned(
-					streamIndex, downlinkFormat, crc, frame, inserted);
+			auto e = m_cache.findWithCA(icaoWithCA);
+			auto& pending = pendingFirstFrame(icaoWithCA);
+			const bool hasPending = pending.valid && pending.icaoWithCA == icaoWithCA;
+
+			if (hasPending
+					&& (m_currTime - pending.sampleTime) < FirstFrameConfirmationTicks)
+				return false;
+
+			if (!e.isValid()) {
+				if (hasPending) {
+					e = m_cache.insertWithCA(icaoWithCA);
+				} else {
+				pendingFirstFrame(icaoWithCA) = PendingFirstFrame{
+					icaoWithCA, downlinkFormat, true, m_currTime, frame};
+				return false;
+				}
 			}
+
+			if (hasPending) {
+				logStatsSent(pending.downlinkFormat);
+				m_messageHandler.handleLong(pending.sampleTime, pending.frame);
+				pending = PendingFirstFrame{};
+			}
+
+			m_cache.markAsTrustedSeen(e);
+			return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 		} else {
 			// the crc is not zero, so we might have a broken message
 			logStats(Stats::DF17_BAD_MESSAGE);
@@ -465,6 +479,22 @@ public:
 
 
 private:
+	struct PendingFirstFrame {
+		uint32_t icaoWithCA { 0 };
+		uint8_t downlinkFormat { 0 };
+		bool valid { false };
+		uint64_t sampleTime { 0 };
+		Bits128 frame { uint64_t(0) };
+	};
+
+	static constexpr size_t PendingFirstFrameCount { 1024 };
+	static constexpr uint64_t FirstFrameConfirmationTicks { 100 * NumStreams };
+
+	PendingFirstFrame& pendingFirstFrame(uint32_t icaoWithCA) noexcept {
+		const auto index = (icaoWithCA * 0x9e3779b1u) >> 22;
+		return m_pendingFirstFrames[index];
+	}
+
 	const void* m_confidenceCtx = nullptr;
 	ConfidenceFn m_confidenceFn = nullptr;
 
@@ -505,7 +535,8 @@ private:
 	alignas(16) uint64_t m_prevShortFrame; 
 
 	// plane lookup table
-	ICAOTable m_cache; 
+	ICAOTable m_cache;
+	std::array<PendingFirstFrame, PendingFirstFrameCount> m_pendingFirstFrames{};
 	
 	// the current time measured in samples.
 	uint64_t m_currTime{ 0 };

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -206,8 +206,11 @@ public:
 				// and send the 112 bit message to the output
 				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 			} else {
-				m_cache.markAsTrustedSeen(m_cache.insertWithCA(icaoWithCA));
-			} 
+				const auto inserted = m_cache.insertWithCA(icaoWithCA);
+				m_cache.markAsTrustedSeen(inserted);
+				return sendFrameLongAligned(
+					streamIndex, downlinkFormat, crc, frame, inserted);
+			}
 		} else {
 			// the crc is not zero, so we might have a broken message
 			logStats(Stats::DF17_BAD_MESSAGE);

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -203,23 +203,22 @@ public:
 			auto& pending = pendingFirstFrame(icaoWithCA);
 			const bool hasPending = pending.valid && pending.icaoWithCA == icaoWithCA;
 
-			if (hasPending
-					&& (m_currTime - pending.sampleTime) < FirstFrameConfirmationTicks)
-				return false;
-
 			if (!e.isValid()) {
-				if (hasPending) {
-					e = m_cache.insertWithCA(icaoWithCA);
-				} else {
+				e = m_cache.insertWithCA(icaoWithCA);
+				m_cache.markAsTrustedSeen(e);
 				pendingFirstFrame(icaoWithCA) = PendingFirstFrame{
 					icaoWithCA, downlinkFormat, true, m_currTime, frame};
 				return false;
-				}
 			}
 
 			if (hasPending) {
-				logStatsSent(pending.downlinkFormat);
-				m_messageHandler.handleLong(pending.sampleTime, pending.frame);
+				const auto age = m_currTime - pending.sampleTime;
+				if (age < FirstFrameConfirmationMinTicks)
+					return false;
+				if (age <= FirstFrameConfirmationMaxTicks) {
+					logStatsSent(pending.downlinkFormat);
+					m_messageHandler.handleLong(pending.sampleTime, pending.frame);
+				}
 				pending = PendingFirstFrame{};
 			}
 
@@ -488,7 +487,8 @@ private:
 	};
 
 	static constexpr size_t PendingFirstFrameCount { 1024 };
-	static constexpr uint64_t FirstFrameConfirmationTicks { 100 * NumStreams };
+	static constexpr uint64_t FirstFrameConfirmationMinTicks { 100 * NumStreams };
+	static constexpr uint64_t FirstFrameConfirmationMaxTicks { 2'000'000 * NumStreams };
 
 	PendingFirstFrame& pendingFirstFrame(uint32_t icaoWithCA) noexcept {
 		const auto index = (icaoWithCA * 0x9e3779b1u) >> 22;

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -20,11 +20,11 @@ public:
 	static constexpr uint32_t DF11CandidateMaxTicks { 2'000'000 };
 	//static constexpr auto ALT_delta_25ft { 80 };
 	static constexpr auto ALT_delta_ft { 2000 };
-    // number if bits used for the look up table 
+	// Number of bits used for the lookup set and entries kept per set.
 	static constexpr auto NumBits { 16 };
-
-    // Length of the table
-	static constexpr auto Size{ 0x1 << NumBits };
+	static constexpr auto NumWays { 2 };
+	static constexpr auto NumSets { 0x1 << NumBits };
+	static constexpr auto Size { NumSets * NumWays };
 
     // lookup mask
     static constexpr uint32_t HashMask{(0x1 << NumBits) - 1};
@@ -85,20 +85,43 @@ public:
 	}
 
 	Iterator insertWithCA(uint32_t icaoWithCA) noexcept  {
-		const auto key = icaoWithCA & HashMask; 
+		const auto base = (icaoWithCA & HashMask) * NumWays;
+		uint32_t key = base;
+		for (uint32_t way = 0; way < NumWays; ++way) {
+			const auto candidate = base + way;
+			if (m_table[candidate].icao == 0) {
+				key = candidate;
+				break;
+			}
+			if (m_table[candidate].ttl_trusted < m_table[key].ttl_trusted
+					|| (m_table[candidate].ttl_trusted == m_table[key].ttl_trusted
+						&& m_table[candidate].ttl < m_table[key].ttl)) {
+				key = candidate;
+			}
+		}
 		doResetEntry(key);
 		m_table[key].icao = icaoWithCA;
 		return Iterator(key);
 	}
 
 	Iterator findWithCA(uint32_t icaoWithCA) const noexcept {
-		const auto key = icaoWithCA & HashMask; 
-		return (m_table[key].icao == icaoWithCA) ? Iterator(key) : Iterator();
+		const auto base = (icaoWithCA & HashMask) * NumWays;
+		for (uint32_t way = 0; way < NumWays; ++way) {
+			const auto key = base + way;
+			if (m_table[key].icao == icaoWithCA)
+				return Iterator(key);
+		}
+		return Iterator();
 	}
 
 	Iterator find(uint32_t icao) const noexcept {
-		const auto key = icao & HashMask; 
-		return ((m_table[key].icao & 0xffffffu) == icao) ? Iterator(key) : Iterator();
+		const auto base = (icao & HashMask) * NumWays;
+		for (uint32_t way = 0; way < NumWays; ++way) {
+			const auto key = base + way;
+			if ((m_table[key].icao & 0xffffffu) == icao)
+				return Iterator(key);
+		}
+		return Iterator();
 	}
 
 	bool confirmDF11Candidate(uint32_t icaoWithCA) noexcept {
@@ -129,15 +152,17 @@ public:
 
 		// if the counter has a value greater than number of entries,
 		// we are done here.
-		if (m_time1Mhz >= (0x1 << NumBits))
+		if (m_time1Mhz >= NumSets)
 			return;
 
-		// do a tick for the next entry otherwise
-		doTickForEntry(m_time1Mhz);
+		// Tick every way in the selected set so each entry ages once per second.
+		const auto base = m_time1Mhz * NumWays;
+		for (uint32_t way = 0; way < NumWays; ++way)
+			doTickForEntry(base + way);
 	}
 
-	/// Membership test against an 8 KB bitmap mirroring "this slot currently
-	/// holds a trusted entry". The table itself is 65536 entries of 8 bytes, so
+	/// Membership test against a 16 KB bitmap mirroring "this slot currently
+	/// holds a trusted entry". The table itself is 131072 entries of 8 bytes, so
 	/// a probe is an L2/DRAM access; callers that test addresses at demodulation
 	/// rate need a filter that stays in L1.
 	///
@@ -146,8 +171,13 @@ public:
 	/// harmless because callers still confirm with findWithCA(), and the tick
 	/// sweep clears it within one pass over the table.
 	bool maybeTrusted(uint32_t icaoWithCA) const noexcept {
-		const auto key = icaoWithCA & HashMask;
-		return (m_trustedBits[key >> 6] >> (key & 63)) & 0x1;
+		const auto base = (icaoWithCA & HashMask) * NumWays;
+		for (uint32_t way = 0; way < NumWays; ++way) {
+			const auto key = base + way;
+			if ((m_trustedBits[key >> 6] >> (key & 63)) & 0x1)
+				return true;
+		}
+		return false;
 	}
 
 	void markAsTrustedSeen(const Iterator& entry) noexcept {
@@ -229,7 +259,7 @@ private:
 
 	std::array<uint64_t, Size / 64> m_trustedBits{};
 
-	void doTickForEntry(uint16_t index) noexcept {
+	void doTickForEntry(uint32_t index) noexcept {
 		auto& entry = m_table[index];
 		if (entry.icao == 0x0)
 			return;
@@ -251,7 +281,7 @@ private:
 			clearTrustedBit(index);
 	}
 
-	void doResetEntry(uint16_t index) noexcept {
+	void doResetEntry(uint32_t index) noexcept {
 		auto& entry = m_table[index];
 		entry.icao = 0x0;
 		entry.ttl_trusted = 0;

--- a/tests/DF17FirstFrameTest.cpp
+++ b/tests/DF17FirstFrameTest.cpp
@@ -2,6 +2,7 @@
 
 #include "DemodCore.hpp"
 
+#include <array>
 #include <cstdint>
 
 namespace {
@@ -9,23 +10,35 @@ namespace {
 struct CapturingHandler {
     void handleShort(uint64_t, uint64_t) {}
 
-    void handleLong(uint64_t, const Bits128& frame) {
-        longCount++;
-        lastLong = frame;
+    void handleLong(uint64_t sampleTime, const Bits128& frame) {
+        if (longCount < frames.size()) {
+            sampleTimes[longCount] = sampleTime;
+            frames[longCount] = frame;
+        }
+        ++longCount;
     }
 
     uint32_t longCount { 0 };
-    Bits128 lastLong;
+    std::array<uint64_t, 2> sampleTimes{};
+    std::array<Bits128, 2> frames { Bits128(), Bits128() };
 };
 
-Bits128 makeDF17(uint32_t icao) {
+Bits128 makeDF17(uint32_t icao, uint8_t typeCode) {
     constexpr uint8_t capability = 5;
     const uint64_t high = (uint64_t(17) << 43)
         | (uint64_t(capability) << 40)
-        | (uint64_t(icao) << 16);
+        | (uint64_t(icao) << 16)
+        | (uint64_t(typeCode) << 11);
     Bits128 frame(high, 0);
     frame.low() = CRC::compute<112>(frame);
     return frame;
+}
+
+void feedSilence(DemodCore<1, CapturingHandler>& demod, uint32_t bits) {
+    for (uint32_t bit = 0; bit < bits; ++bit) {
+        uint32_t value[] = { 0 };
+        demod.shiftInNewBits(value);
+    }
 }
 
 void feedFrame(DemodCore<1, CapturingHandler>& demod, const Bits128& frame) {
@@ -43,13 +56,38 @@ void feedFrame(DemodCore<1, CapturingHandler>& demod, const Bits128& frame) {
 } // namespace
 
 int main() {
-    const auto frame = makeDF17(0xabcdef);
-    if (CRC::compute<112>(frame) != 0)
+    const auto first = makeDF17(0xabcdef, 1);
+    const auto second = makeDF17(0xabcdef, 2);
+    const auto unrelated = makeDF17(0x123456, 1);
+    auto repairCandidate = makeDF17(0xabcdef, 3);
+    repairCandidate.flip(30);
+    if (CRC::compute<112>(first) != 0
+            || CRC::compute<112>(second) != 0
+            || CRC::compute<112>(unrelated) != 0
+            || CRC::compute<112>(repairCandidate) == 0)
         return 1;
 
     CapturingHandler handler;
     DemodCore<1, CapturingHandler> demod(handler);
-    feedFrame(demod, frame);
+    feedFrame(demod, first);
+    if (handler.longCount != 0)
+        return 1;
 
-    return !(handler.longCount == 1 && handler.lastLong == frame);
+    feedSilence(demod, 128);
+    feedFrame(demod, unrelated);
+    if (handler.longCount != 0)
+        return 1;
+
+    feedSilence(demod, 128);
+    feedFrame(demod, repairCandidate);
+    if (handler.longCount != 0)
+        return 1;
+
+    feedSilence(demod, 128);
+    feedFrame(demod, second);
+
+    return !(handler.longCount == 2
+        && handler.frames[0] == first
+        && handler.frames[1] == second
+        && handler.sampleTimes[0] < handler.sampleTimes[1]);
 }

--- a/tests/DF17FirstFrameTest.cpp
+++ b/tests/DF17FirstFrameTest.cpp
@@ -59,12 +59,9 @@ int main() {
     const auto first = makeDF17(0xabcdef, 1);
     const auto second = makeDF17(0xabcdef, 2);
     const auto unrelated = makeDF17(0x123456, 1);
-    auto repairCandidate = makeDF17(0xabcdef, 3);
-    repairCandidate.flip(30);
     if (CRC::compute<112>(first) != 0
             || CRC::compute<112>(second) != 0
-            || CRC::compute<112>(unrelated) != 0
-            || CRC::compute<112>(repairCandidate) == 0)
+            || CRC::compute<112>(unrelated) != 0)
         return 1;
 
     CapturingHandler handler;
@@ -79,15 +76,20 @@ int main() {
         return 1;
 
     feedSilence(demod, 128);
-    feedFrame(demod, repairCandidate);
-    if (handler.longCount != 0)
-        return 1;
-
-    feedSilence(demod, 128);
     feedFrame(demod, second);
 
-    return !(handler.longCount == 2
+    if (!(handler.longCount == 2
         && handler.frames[0] == first
         && handler.frames[1] == second
-        && handler.sampleTimes[0] < handler.sampleTimes[1]);
+        && handler.sampleTimes[0] < handler.sampleTimes[1]))
+        return 1;
+
+    CapturingHandler expiredHandler;
+    DemodCore<1, CapturingHandler> expiredDemod(expiredHandler);
+    feedFrame(expiredDemod, first);
+    feedSilence(expiredDemod, 2'000'001);
+    feedFrame(expiredDemod, second);
+
+    return !(expiredHandler.longCount == 1
+        && expiredHandler.frames[0] == second);
 }

--- a/tests/DF17FirstFrameTest.cpp
+++ b/tests/DF17FirstFrameTest.cpp
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "DemodCore.hpp"
+
+#include <cstdint>
+
+namespace {
+
+struct CapturingHandler {
+    void handleShort(uint64_t, uint64_t) {}
+
+    void handleLong(uint64_t, const Bits128& frame) {
+        longCount++;
+        lastLong = frame;
+    }
+
+    uint32_t longCount { 0 };
+    Bits128 lastLong;
+};
+
+Bits128 makeDF17(uint32_t icao) {
+    constexpr uint8_t capability = 5;
+    const uint64_t high = (uint64_t(17) << 43)
+        | (uint64_t(capability) << 40)
+        | (uint64_t(icao) << 16);
+    Bits128 frame(high, 0);
+    frame.low() = CRC::compute<112>(frame);
+    return frame;
+}
+
+void feedFrame(DemodCore<1, CapturingHandler>& demod, const Bits128& frame) {
+    for (int bit = 111; bit >= 0; --bit) {
+        uint32_t value[] = { uint32_t(frame.get(bit)) };
+        demod.shiftInNewBits(value);
+    }
+
+    for (int bit = 0; bit < 16; ++bit) {
+        uint32_t value[] = { 0 };
+        demod.shiftInNewBits(value);
+    }
+}
+
+} // namespace
+
+int main() {
+    const auto frame = makeDF17(0xabcdef);
+    if (CRC::compute<112>(frame) != 0)
+        return 1;
+
+    CapturingHandler handler;
+    DemodCore<1, CapturingHandler> demod(handler);
+    feedFrame(demod, frame);
+
+    return !(handler.longCount == 1 && handler.lastLong == frame);
+}

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -51,10 +51,27 @@ bool hashCollisionsCannotConfirmAnotherAddress() {
     return !table.confirmDF11Candidate(first);
 }
 
+bool lookupCollisionsCanCoexist() {
+    ICAOTable table;
+    constexpr uint32_t first = 0x1abcde;
+    constexpr uint32_t second = 0x2abcde;
+
+    const auto firstEntry = table.insertWithCA(first);
+    table.markAsTrustedSeen(firstEntry);
+    const auto secondEntry = table.insertWithCA(second);
+    table.markAsTrustedSeen(secondEntry);
+
+    return table.find(first).isValid()
+        && table.find(second).isValid()
+        && table.maybeTrusted(first)
+        && table.maybeTrusted(second);
+}
+
 } // namespace
 
 int main() {
     return !(confirmsOnlySeparateSightings()
         && expiresOldSightings()
-        && hashCollisionsCannotConfirmAnotherAddress());
+        && hashCollisionsCannotConfirmAnotherAddress()
+        && lookupCollisionsCanCoexist());
 }


### PR DESCRIPTION
## What changed

- hold the first CRC-clean DF17/18/19 frame for an unknown ICAO while seeding the cache with the existing trust semantics
- release the held frame with its original timestamp only after a second CRC-clean sighting of the same ICAO/CA between 100 microseconds and two seconds later
- make the ICAO cache two-way set-associative, retaining two active aircraft that share the same 16-bit lookup key
- add regression coverage for isolated candidates, unrelated ICAOs, confirmed first-frame release, confirmation expiry, and cache collisions

## Why

The direct-mapped cache could make active aircraft evict one another when their addresses shared the same low 16 bits. Stream1090 also withheld the first CRC-clean extended squitter from an unknown address, but emitting it immediately would allow an isolated 24-bit CRC collision into the output.

The pending-candidate gate recovers that first frame only after an independent clean sighting. Cache trust remains unchanged from `main`; the new gate applies only to the additional first-frame output. The pending table is deliberately lossy: a hash collision can prevent first-frame recovery, but cannot confirm an address.

## Replay evidence

An earlier immediate-emission prototype was rejected after output-level analysis found 4 one-off ICAO addresses in the 59.8-second replay and 16 in the 145.9-second replay. Deterministic replays of three Airspy U16 real captures from `/home/enrico/captures/` at 6 Msps, demodulated at 24 MHz with the built-in FIR, produced these results against main at `ce230ac`:

| Capture | Baseline | This PR | Difference |
| --- | ---: | ---: | ---: |
| 59.8 seconds | 31,852 | 31,940 | +88 (+0.276%) |
| 89.8 seconds | 56,929 | 56,961 | +32 (+0.056%) |
| 145.9 seconds | 75,892 | 76,067 | +175 (+0.231%) |
| **Combined** | **164,673** | **164,968** | **+295 (+0.179%)** |

No added explicit-address frame introduced an ICAO seen only once in the candidate output. Preserving the held frame's timestamp makes the output temporarily non-monotonic; the largest observed reversals were 1.537 s, 1.745 s, and 1.833 s respectively, bounded by the two-second confirmation window.

## Validation

- rebased onto current `origin/main` at `6f1480b`
- clean Release build with Airspy and RTL-SDR support after the rebase
- local test suite after the rebase: 6/6 passed
- original GitHub Actions run: GCC, Clang, and build without device backends all passed
- byte-identical source fan-out to the original baseline and candidate for the 89.8-second and 145.9-second replays
- sequential replay of the same unchanged 59.8-second source against both original builds
- output-delta checks for per-DF additions/removals, explicit-address singleton ICAOs, and timestamp reversals
