### PR TITLE
Demod: branchless CRC update and a cheaper dispatch

### DIFF
--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -14,6 +14,7 @@
 #include "ModeS.hpp"
 #include "ICAOCache.hpp"
 #include "Stats.hpp"
+#include <bit>
 #include <cmath>
 #include "ShiftRegisters.hpp"
 #include "MessageHandler.hpp"
@@ -47,13 +48,23 @@ public:
 	}
 
 	void shiftInNewBits(uint32_t* cmp) {
-		m_shiftRegisters.shiftInNewBits(cmp); 
+		// the shift registers tell us which streams ended up on a downlink
+		// format we handle. That is a rare event, so most calls leave here
+		// without touching the dispatcher at all.
+		uint64_t handledStreams = m_shiftRegisters.shiftInNewBits(cmp);
 		// the streams and crc's are ready
 		m_cache.tick();
-		for (auto i = 0; i < NumStreams; i++) {
-			handleStream(i);			
-			m_currTime++;
+
+		const uint64_t baseTime = m_currTime;
+		while (handledStreams) {
+			const auto i = std::countr_zero(handledStreams);
+			// handleStream() looks at m_currTime, so keep it in step
+			m_currTime = baseTime + i;
+			handleStream(i);
+			handledStreams &= handledStreams - 1;
 		}
+		m_currTime = baseTime + NumStreams;
+
 		logStats(Stats::NUM_ITERATIONS);
 	}
 

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -120,9 +120,13 @@ public:
 
 	void tick() noexcept {
 		m_df11Clock++;
-		// the counter will wrap around every second exactly once
-		m_time1Mhz = (m_time1Mhz + 1) % 1000000;
 		
+		// the counter will wrap around every second exactly once.
+		// A compare beats the modulo here: this runs once per microsecond and
+		// the branch is taken once per second.
+		if (++m_time1Mhz == 1000000)
+			m_time1Mhz = 0;
+
 		// if the counter has a value greater than number of entries,
 		// we are done here.
 		if (m_time1Mhz >= (0x1 << NumBits))

--- a/include/ShiftRegisters.hpp
+++ b/include/ShiftRegisters.hpp
@@ -10,9 +10,20 @@
 #include "Bits128.hpp"
 #include "CRC.hpp"
 
+// Downlink formats the demodulator actually looks at: 0, 4, 5, 11, 16, 17, 18,
+// 19, 20, 21. Every other value is dropped right away, so the shift register
+// can tell the caller which streams are worth a closer look and which are not.
+inline constexpr uint32_t handledDownlinkFormats =
+      (1u <<  0) | (1u <<  4) | (1u <<  5) | (1u << 11)
+    | (1u << 16) | (1u << 17) | (1u << 18) | (1u << 19)
+    | (1u << 20) | (1u << 21);
+
 template<int NumStreams>
 class alignas(16) ShiftRegistersBase {
     public:
+
+    // one bit per stream has to fit into the returned mask
+    static_assert(NumStreams <= 64, "stream mask is 64 bit wide");
 
     constexpr ShiftRegistersBase() noexcept {
         for (auto i = 0; i < NumStreams; i++) {
@@ -24,30 +35,31 @@ class alignas(16) ShiftRegistersBase {
         };
     }
 
-    constexpr const CRC::crc_t& getCRC_56(auto i) const noexcept {
-        return m_crc_56[i];
+    constexpr CRC::crc_t getCRC_56(auto i) const noexcept {
+        return (CRC::crc_t)m_crc_56[i];
     }
 
-    constexpr const CRC::crc_t& getCRC_112(auto i) const noexcept {
-        return m_crc_112[i];
+    constexpr CRC::crc_t getCRC_112(auto i) const noexcept {
+        return (CRC::crc_t)m_crc_112[i];
     }
 
-    constexpr const uint32_t& getDF(auto i) const noexcept{
-        return m_df[i];
+    constexpr uint32_t getDF(auto i) const noexcept{
+        return (uint32_t)m_df[i];
     }
 
     protected:
 
-    uint64_t m_low[NumStreams];    
+    uint64_t m_low[NumStreams];
     uint64_t m_high[NumStreams];
-    
-	// And a checksum for the short messages (56 bit)
-	CRC::crc_t m_crc_56[NumStreams];
+
+	// And a checksum for the short messages (56 bit). Held in 64 bit so the
+	// masked update below needs no narrowing in the middle of the chain.
+	uint64_t m_crc_56[NumStreams];
 
     // Each stream has a checksum for long messages (112 bit)
-	CRC::crc_t m_crc_112[NumStreams];
+	uint64_t m_crc_112[NumStreams];
 
-    uint32_t m_df[NumStreams];
+    uint64_t m_df[NumStreams];
 };
 
 
@@ -56,33 +68,50 @@ class alignas(16) ShiftRegisters : public ShiftRegistersBase<NumStreams> {
     public:
         constexpr ShiftRegisters() : ShiftRegistersBase<NumStreams>() { }
 
-        constexpr void shiftInNewBits(const uint32_t* cmp) noexcept {
+        /// Shifts one new bit into every stream and updates both CRCs.
+        /// Returns a mask with bit i set when stream i now shows a downlink
+        /// format the demodulator handles.
+        ///
+        /// The two conditionals of the textbook version (did we shift a one out
+        /// of the register, did the CRC overflow past 24 bits) are replaced by
+        /// masks. Both are close to coin flips, so as branches they were mostly
+        /// mispredictions, and without them the loop has no control flow left
+        /// for the compiler to trip over.
+        uint64_t shiftInNewBits(const uint32_t* cmp) noexcept {
+            uint64_t handledMask = 0;
+
             for (auto i = 0; i < NumStreams; i++) {
-                // check if we shift out the msb 
-                if (this->m_df[i] > 0xf) {
-                    // adjust the 56 bit crc
-                    this->m_crc_56[i]  ^= CRC::delta<55>();//  * (m_bits[i].high() >> 63);
-                    // adjust the 112 bit crc accordingly
-                    this->m_crc_112[i] ^= CRC::delta<111>();// * (m_bits[i].high() >> 63);
-                };
-            
-                this->m_crc_56[i]  = (this->m_crc_56[i] << 1) | ((this->m_high[i] >> 7) & 0x1);
-                this->m_crc_112[i] = (this->m_crc_112[i]<< 1) | ((this->m_low[i] >> 15) & 0x1);
+                const uint64_t high = this->m_high[i];
+                const uint64_t low  = this->m_low[i];
 
-                this->m_high[i] = (this->m_high[i] << 1) | (this->m_low[i] >> 63);
-                this->m_low[i]  = (this->m_low[i] << 1) | cmp[i];           
-                this->m_df[i] = this->m_high[i] >> 59;
+                // all ones when a one bit leaves the register at the top
+                const uint64_t shiftedOut = uint64_t(0) - (high >> 63);
 
-                // if the current crc is too large, shorten it with the polynomial
-                if (this->m_crc_56[i] > 0xfffffful) {
-                    this->m_crc_56[i] ^= CRC::polynomial;
-                }
+                uint64_t crc56  = this->m_crc_56[i]  ^ (Delta55  & shiftedOut);
+                uint64_t crc112 = this->m_crc_112[i] ^ (Delta111 & shiftedOut);
 
-                 // same for the crc of the 112 bits
-                if (this->m_crc_112[i] > 0xfffffful) {
-                    this->m_crc_112[i] ^= CRC::polynomial;
-                }
+                crc56  = (crc56  << 1) | ((high >> 7)  & 0x1);
+                crc112 = (crc112 << 1) | ((low  >> 15) & 0x1);
+
+                const uint64_t newHigh = (high << 1) | (low >> 63);
+                const uint64_t newLow  = (low  << 1) | cmp[i];
+                const uint64_t df      = newHigh >> 59;
+
+                // Fold the polynomial back in whenever bit 24 is set. The CRC
+                // never exceeds 25 bits here, so the shift is a 0/1 flag.
+                crc56  ^= Polynomial & (uint64_t(0) - (crc56  >> 24));
+                crc112 ^= Polynomial & (uint64_t(0) - (crc112 >> 24));
+
+                this->m_crc_56[i]  = crc56;
+                this->m_crc_112[i] = crc112;
+                this->m_high[i]    = newHigh;
+                this->m_low[i]     = newLow;
+                this->m_df[i]      = df;
+
+                handledMask |= uint64_t((handledDownlinkFormats >> df) & 0x1) << i;
             }
+
+            return handledMask;
         }
 
         constexpr Bits128 extractAlignedFrameLong(auto i) const noexcept {
@@ -92,6 +121,10 @@ class alignas(16) ShiftRegisters : public ShiftRegistersBase<NumStreams> {
         constexpr uint64_t extractAlignedFrameShort(auto i) const noexcept {
             return (this->m_high[i] >> 8);
         }
+
+    private:
+        static constexpr uint64_t Delta55  = CRC::delta<55>();
+        static constexpr uint64_t Delta111 = CRC::delta<111>();
+        static constexpr uint64_t Polynomial = CRC::polynomial;
+
 };
-
-


### PR DESCRIPTION
Two changes to the per sample hot path of the demodulator. No behaviour change, no new build options, no intrinsics.

## What it does

**The shift register update loses its two branches.** `shiftInNewBits()` asked two questions per stream per sample: did a one bit leave the register at the top, and did the CRC pass 24 bits. Both are close to coin flips, so as branches they were mostly mispredictions. As masks they cost a couple of instructions each and leave the loop with no control flow in it.

**The dispatcher stops walking every stream.** `shiftInNewBits()` now returns a mask with a bit set for each stream that landed on a downlink format the demodulator actually handles — 0, 4, 5, 11, 16 through 21. The format field is mostly noise, so walking that mask instead of calling `handleStream()` unconditionally drops roughly two thirds of the calls into the switch. `m_currTime` is still advanced exactly as before, so the timestamps and the duplicate windows are untouched.

Alongside that, `ICAOTable::tick()` trades a modulo by 1000000 for a compare. It runs once per microsecond and the branch is taken once per second.

The CRC accumulators move from `crc_t` to `uint64_t` so the masked update needs no narrowing mid chain. The values themselves never exceed 24 bits, and the getters still hand out `crc_t`.

## Measurements

Raspberry Pi 4, Cortex-A72, gcc 14.2, default build flags. Input is 25 s of a real 6 Msps Airspy capture, replayed from tmpfs so the SD card is out of the loop, `-s 6 -u 24 -q`. User CPU seconds, best of three:

| | best | all three runs |
| --- | --- | --- |
| main | 28.87 s | 28.87 / 29.41 / 29.80 |
| this branch | **26.92 s** | 26.92 / 27.41 / 27.95 |

A 6.8% saving. The distributions do not overlap. The box was running a live `stream1090` on the same four cores throughout, which is the load these boards actually see.

## Verification

The same capture decodes to the same **13045 messages, byte for byte identical output**, on `main` and on this branch. That holds for 6 -> 6, 6 -> 12 and 6 -> 24, with the built in taps, with taps from a file, and with no filter at all — checked on the Pi and again on aarch64 macOS with clang.

## A note on what is not here

An earlier version of this change carried a hand written NEON kernel for the shift register update, running two streams per vector, behind an `ENABLE_SIMD` switch with a scalar fallback.

I measured it on the Cortex-A72 it was written for and it bought nothing: 27.56 s with the kernel against 26.92 s without, distributions overlapping. The win is entirely in removing the branches — once the loop has no control flow left, gcc does at least as well on its own as the intrinsics did. So the kernel, the `Simd.hpp` header and the build option are all dropped, and what is left is the part that actually pays.
