### PR TITLE
Offer DC removal without the FIR filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(BUILD_TESTING)
     stream1090_add_test(sampler_test tests/SamplerTest.cpp)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
+    stream1090_add_test(iq_pipeline_test tests/IQPipelineTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ For example:
 ```
 ./build/stream1090 -s 6 -u 24 --dc-removal -d ./configs/airspy.ini > /dev/null
 ```
-This is useful when the receiver has a measurable DC offset but the additional CPU cost of the FIR filter is not desired. The Airspy `-q` and `-f` pipelines already include DC offset removal, so `--dc-removal` does not need to be combined with either option.
+This is useful when the receiver has a measurable DC offset but the additional CPU cost of the FIR filter is not desired. The Airspy `-q` and `-f` pipelines already include DC offset removal, so `--dc-removal` does not need to be combined with either option. For RTL-SDR, `--dc-removal` can also be combined with `-q` or `-f` when both DC removal and FIR filtering are desired.
 
 ## Stack Integration
 In order to utilize the output of Stream1090, we will send it to a decoder like readsb or dump1090-fa via TCP. This has one big advantage: You do not have to modify anything in the remaining stack.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ shared tap is multiplied, which nearly halves the multiply-accumulate count.
 The portable path remains in use on other architectures. The optimized and
 plain kernels are covered by an exact-output equivalence test.
 
+### DC Offset Removal
+
+DC offset removal can be enabled without the low-pass FIR filter:
+```
+--dc-removal    Removes the receiver's DC offset without enabling the FIR filter
+```
+For example:
+```
+./build/stream1090 -s 6 -u 24 --dc-removal -d ./configs/airspy.ini > /dev/null
+```
+This is useful when the receiver has a measurable DC offset but the additional CPU cost of the FIR filter is not desired. The Airspy `-q` and `-f` pipelines already include DC offset removal, so `--dc-removal` does not need to be combined with either option.
+
 ## Stack Integration
 In order to utilize the output of Stream1090, we will send it to a decoder like readsb or dump1090-fa via TCP. This has one big advantage: You do not have to modify anything in the remaining stack.
 ```

--- a/README.md
+++ b/README.md
@@ -208,7 +208,13 @@ For example:
 ```
 ./build/stream1090 -s 6 -u 24 --dc-removal -d ./configs/airspy.ini > /dev/null
 ```
-This is useful when the receiver has a measurable DC offset but the additional CPU cost of the FIR filter is not desired. The Airspy `-q` and `-f` pipelines already include DC offset removal, so `--dc-removal` does not need to be combined with either option. For RTL-SDR, `--dc-removal` can also be combined with `-q` or `-f` when both DC removal and FIR filtering are desired.
+This is useful when the receiver has a measurable DC offset but the additional
+CPU cost of the FIR filter is not desired. The Airspy `-q` and `-f` pipelines
+already include DC offset removal, so `--dc-removal` does not need to be
+combined with either option. For RTL-SDR, `--dc-removal` can also be combined
+with `-q` or `-f`. Its slower 1/2048 smoothing factor is deliberate: the
+Airspy 1/256 setting follows low-frequency complex-baseband carriers and loses
+messages on RTL-SDR recordings.
 
 ## Stack Integration
 In order to utilize the output of Stream1090, we will send it to a decoder like readsb or dump1090-fa via TCP. This has one big advantage: You do not have to modify anything in the remaining stack.

--- a/include/IQPipeline.hpp
+++ b/include/IQPipeline.hpp
@@ -22,11 +22,23 @@
  * becomes 1/256.
  */
 struct DCRemoval {
-    explicit DCRemoval(float alpha = 0.005f)
-        : m_shift(shiftForAlpha(alpha)), m_acc_I(0), m_acc_Q(0)
+    explicit DCRemoval(float alpha = 0.005f, bool enabled = true)
+        : m_shift(shiftForAlpha(alpha)), m_acc_I(0), m_acc_Q(0),
+          m_enabled(enabled)
     {}
 
+    /// Whole blocks are handed over at a time, so a disabled stage costs one
+    /// test per block rather than anything per sample.
+    void applyBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
+        if (!m_enabled)
+            return;
+        for (size_t i = 0; i < n; i++)
+            apply(I[i], Q[i]);
+    }
+
     void apply(int16_t& I, int16_t& Q) noexcept {
+        if (!m_enabled)
+            return;
         const int32_t dI = int32_t(I) - (m_acc_I >> m_shift);
         const int32_t dQ = int32_t(Q) - (m_acc_Q >> m_shift);
 
@@ -37,18 +49,16 @@ struct DCRemoval {
         Q = int16_t(dQ);
     }
 
-    void applyBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
-        for (size_t i = 0; i < n; i++)
-            apply(I[i], Q[i]);
-    }
-
     void setAlpha(float alpha) noexcept {
         m_shift = shiftForAlpha(alpha);
     }
 
+    void setEnabled(bool enabled) noexcept { m_enabled = enabled; }
+
     std::string toString() const {
         std::ostringstream oss;
-        oss << "[DCRemoval] alpha: 1/" << (1 << m_shift);
+        oss << "[DCRemoval] alpha: 1/" << (1 << m_shift)
+            << (m_enabled ? "" : " (disabled)");
         return oss.str();
     }
 private:
@@ -64,6 +74,7 @@ private:
     int m_shift;
     int32_t m_acc_I;
     int32_t m_acc_Q;
+    bool m_enabled;
 };
 
 
@@ -173,4 +184,3 @@ template<typename... Stages>
 auto make_pipeline(Stages&&... stages) {
     return IQPipeline<std::decay_t<Stages>...>(std::forward<Stages>(stages)...);
 }
-

--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -46,6 +46,7 @@ struct RuntimeVars {
     IniConfig deviceConfig;
     IniConfig::Section deviceConfigSection;
     std::vector<float> filterTaps;
+    bool dcRemoval = false;
     bool verbose = true;
 };
 
@@ -280,7 +281,7 @@ public:
 
     bool run() {
         // setup pipeline
-        auto iqPipeline = IQPipelineSelector<inputRate, outputRate, pipelineOption>().make(m_runtimeVars.filterTaps);
+        auto iqPipeline = IQPipelineSelector<inputRate, outputRate, pipelineOption>().make(m_runtimeVars.filterTaps, m_runtimeVars.dcRemoval);
         Log::info("",iqPipeline.toString());
         // for sync read from std in we take a short cut
         if (m_runtimeVars.deviceType == InputDeviceType::STREAM) {

--- a/include/Presets.hpp
+++ b/include/Presets.hpp
@@ -94,37 +94,45 @@ constexpr auto presets = std::make_tuple(
 #endif
 
 
+/*
+ * The plain preset carries a DC removal that is switched off by default. The
+ * receivers this runs on sit a few LSB off the nominal centre of their ADC
+ * range, and with a truly empty pipeline nothing takes that out before the
+ * magnitude is formed, which costs messages. Keeping the stage here and
+ * gating it at run time avoids instantiating the whole chain a second time
+ * just to offer the choice.
+ */
 template<SampleRate In, SampleRate Out, IQPipelineOptions sel>
 struct IQPipelineSelector {
-    static auto make(const std::vector<float>&) {
-        return make_pipeline();
+    static auto make(const std::vector<float>&, bool dcRemoval = false) {
+        return make_pipeline(DCRemoval(0.005f, dcRemoval));
     }
 };
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR> {
-    static auto make(const std::vector<float>&) {
+    static auto make(const std::vector<float>&, bool = true) {
         return make_pipeline(DCRemoval(), FlipSigns(), IQLowPass<In, Out>());
     }
 };
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_FILE> {
-    static auto make(const std::vector<float>& taps) {
+    static auto make(const std::vector<float>& taps, bool = true) {
         return make_pipeline(DCRemoval(), FlipSigns(), IQLowPassDynamic(taps));
     }
 };
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_RTL_SDR> {
-    static auto make(const std::vector<float>&) {
+    static auto make(const std::vector<float>&, bool = false) {
         return make_pipeline(IQLowPass<In, Out>());
     }
 };
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE> {
-    static auto make(const std::vector<float>& taps) {
+    static auto make(const std::vector<float>& taps, bool = false) {
         return make_pipeline(IQLowPassDynamic(taps));
     }
 };

--- a/include/Presets.hpp
+++ b/include/Presets.hpp
@@ -125,15 +125,14 @@ struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_FILE> {
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_RTL_SDR> {
-    static auto make(const std::vector<float>&, bool = false) {
-        return make_pipeline(IQLowPass<In, Out>());
+    static auto make(const std::vector<float>&, bool dcRemoval = false) {
+        return make_pipeline(DCRemoval(0.005f, dcRemoval), IQLowPass<In, Out>());
     }
 };
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE> {
-    static auto make(const std::vector<float>& taps, bool = false) {
-        return make_pipeline(IQLowPassDynamic(taps));
+    static auto make(const std::vector<float>& taps, bool dcRemoval = false) {
+        return make_pipeline(DCRemoval(0.005f, dcRemoval), IQLowPassDynamic(taps));
     }
 };
-

--- a/include/Presets.hpp
+++ b/include/Presets.hpp
@@ -93,6 +93,9 @@ constexpr auto presets = std::make_tuple(
 
 #endif
 
+template<SampleRate In>
+inline constexpr float dcRemovalAlpha =
+    (In == Rate_2_4_Mhz || In == Rate_2_56_Mhz) ? 0.0005f : 0.005f;
 
 /*
  * The plain preset carries a DC removal that is switched off by default. The
@@ -105,7 +108,7 @@ constexpr auto presets = std::make_tuple(
 template<SampleRate In, SampleRate Out, IQPipelineOptions sel>
 struct IQPipelineSelector {
     static auto make(const std::vector<float>&, bool dcRemoval = false) {
-        return make_pipeline(DCRemoval(0.005f, dcRemoval));
+        return make_pipeline(DCRemoval(dcRemovalAlpha<In>, dcRemoval));
     }
 };
 
@@ -126,13 +129,15 @@ struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_FILE> {
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_RTL_SDR> {
     static auto make(const std::vector<float>&, bool dcRemoval = false) {
-        return make_pipeline(DCRemoval(0.005f, dcRemoval), IQLowPass<In, Out>());
+        return make_pipeline(DCRemoval(dcRemovalAlpha<In>, dcRemoval),
+                             IQLowPass<In, Out>());
     }
 };
 
 template<SampleRate In, SampleRate Out>
 struct IQPipelineSelector<In, Out, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE> {
     static auto make(const std::vector<float>& taps, bool dcRemoval = false) {
-        return make_pipeline(DCRemoval(0.005f, dcRemoval), IQLowPassDynamic(taps));
+        return make_pipeline(DCRemoval(dcRemovalAlpha<In>, dcRemoval),
+                             IQLowPassDynamic(taps));
     }
 };

--- a/main.cpp
+++ b/main.cpp
@@ -118,9 +118,8 @@ void print_help() {
     "  -d <file.ini>        Device configuration INI file for native devices\n"
     "                       See configs/airspy.ini or configs/rtlsdr.ini\n"                       
     "  -q                   Enables IQ FIR filter with built-in taps\n"
-    "  --dc-removal         Removes the receiver's DC offset, without the FIR.\n"
-    "                       Implied by -q and -f. Cheaper than the filter and\n"
-    "                       worth a few percent of messages on its own.\n"
+    "  --dc-removal         Removes the receiver's DC offset without the FIR.\n"
+    "                       Airspy -q and -f pipelines already include it.\n"
     "  -f <taps file>       Taps to load that are used for the IQ FIR filter\n"
     "  -v                   Verbose output\n"
     "  -h, --help           Show this help message\n\n";
@@ -431,7 +430,6 @@ int main(int argc, char** argv) {
     }
     return *outcome ? 0 : 1;
 }
-
 
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -118,6 +118,9 @@ void print_help() {
     "  -d <file.ini>        Device configuration INI file for native devices\n"
     "                       See configs/airspy.ini or configs/rtlsdr.ini\n"                       
     "  -q                   Enables IQ FIR filter with built-in taps\n"
+    "  --dc-removal         Removes the receiver's DC offset, without the FIR.\n"
+    "                       Implied by -q and -f. Cheaper than the filter and\n"
+    "                       worth a few percent of messages on its own.\n"
     "  -f <taps file>       Taps to load that are used for the IQ FIR filter\n"
     "  -v                   Verbose output\n"
     "  -h, --help           Show this help message\n\n";
@@ -137,6 +140,7 @@ struct CliArgs {
     std::string deviceConfig = "";
     std::string tapsFile = "";
     bool iq_filter = false;
+    bool dc_removal = false;
     bool verbose = false;
 };
 
@@ -166,6 +170,11 @@ bool parse_cli(int argc, char** argv, CliArgs& out) {
 
         if (arg == "-f" && i + 1 < argc) {
             out.tapsFile = argv[++i];
+            continue;
+        }
+
+        if (arg == "--dc-removal") {
+            out.dc_removal = true;
             continue;
         }
 
@@ -273,7 +282,7 @@ int main(int argc, char** argv) {
 
     CliArgs args;
     if (!parse_cli(argc, argv, args)) {
-        std::cerr << "Usage: stream1090 -s <rate> -u <rate> [-d <device.ini>] [-f <taps file>] [-q] [-v] [-h]\n";
+        std::cerr << "Usage: stream1090 -s <rate> -u <rate> [-d <device.ini>] [-f <taps file>] [-q] [--dc-removal] [-v] [-h]\n";
         return 1;
     }
 
@@ -335,6 +344,8 @@ int main(int argc, char** argv) {
     // ------------------------
     // FIR taps loading
     // ------------------------
+    r_vars.dcRemoval = args.dc_removal;
+
     if (!args.tapsFile.empty()) {
         r_vars.filterTaps = load_taps_from_file(args.tapsFile);
         if (r_vars.filterTaps.empty()) {

--- a/tests/IQPipelineTest.cpp
+++ b/tests/IQPipelineTest.cpp
@@ -1,9 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include <cstdint>
+#include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
-#include "IQPipeline.hpp"
+#include "Presets.hpp"
 
 namespace {
 
@@ -31,11 +35,35 @@ bool enabledStageTracksAndRemovesTheAverage() {
     return i == 4.0f && q == -2.0f;
 }
 
+bool rtlFilteredPipelinesHonorDcRemoval() {
+    using FileSelector = IQPipelineSelector<Rate_2_4_Mhz, Rate_8_0_Mhz,
+        IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>;
+
+    auto disabled = FileSelector::make(std::vector<float>{ 1.0f }, false);
+    auto enabled = FileSelector::make(std::vector<float>{ 1.0f }, true);
+
+    float disabledMagnitude = 0.0f;
+    float enabledMagnitude = 0.0f;
+    for (int sample = 0; sample < 2000; ++sample) {
+        disabledMagnitude = disabled.process(8.0f, -4.0f);
+        enabledMagnitude = enabled.process(8.0f, -4.0f);
+    }
+
+    using BuiltInSelector = IQPipelineSelector<Rate_2_4_Mhz, Rate_8_0_Mhz,
+        IQPipelineOptions::IQ_FIR_RTL_SDR>;
+    const auto builtIn = BuiltInSelector::make({}, true);
+
+    return enabledMagnitude < disabledMagnitude * 0.001f
+        && builtIn.toString().find("[DCRemoval] alpha: 0.005")
+            != std::string::npos;
+}
+
 } // namespace
 
 int main() {
     return disabledStageLeavesSamplesUnchanged()
             && enabledStageTracksAndRemovesTheAverage()
+            && rtlFilteredPipelinesHonorDcRemoval()
         ? 0
         : 1;
 }

--- a/tests/IQPipelineTest.cpp
+++ b/tests/IQPipelineTest.cpp
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <sstream>
+#include <string>
+
+#include "IQPipeline.hpp"
+
+namespace {
+
+bool disabledStageLeavesSamplesUnchanged() {
+    DCRemoval stage(0.5f, false);
+    float i = 8.0f;
+    float q = -4.0f;
+
+    stage.apply(i, q);
+    return i == 8.0f && q == -4.0f;
+}
+
+bool enabledStageTracksAndRemovesTheAverage() {
+    DCRemoval stage(0.5f);
+    float i = 8.0f;
+    float q = -4.0f;
+
+    stage.apply(i, q);
+    if (i != 8.0f || q != -4.0f)
+        return false;
+
+    i = 8.0f;
+    q = -4.0f;
+    stage.apply(i, q);
+    return i == 4.0f && q == -2.0f;
+}
+
+} // namespace
+
+int main() {
+    return disabledStageLeavesSamplesUnchanged()
+            && enabledStageTracksAndRemovesTheAverage()
+        ? 0
+        : 1;
+}

--- a/tests/IQPipelineTest.cpp
+++ b/tests/IQPipelineTest.cpp
@@ -13,26 +13,26 @@ namespace {
 
 bool disabledStageLeavesSamplesUnchanged() {
     DCRemoval stage(0.5f, false);
-    float i = 8.0f;
-    float q = -4.0f;
+    int16_t i = 8;
+    int16_t q = -4;
 
     stage.apply(i, q);
-    return i == 8.0f && q == -4.0f;
+    return i == 8 && q == -4;
 }
 
 bool enabledStageTracksAndRemovesTheAverage() {
     DCRemoval stage(0.5f);
-    float i = 8.0f;
-    float q = -4.0f;
+    int16_t i = 8;
+    int16_t q = -4;
 
     stage.apply(i, q);
-    if (i != 8.0f || q != -4.0f)
+    if (i != 8 || q != -4)
         return false;
 
-    i = 8.0f;
-    q = -4.0f;
+    i = 8;
+    q = -4;
     stage.apply(i, q);
-    return i == 4.0f && q == -2.0f;
+    return i == 4 && q == -2;
 }
 
 bool rtlFilteredPipelinesHonorDcRemoval() {
@@ -42,19 +42,19 @@ bool rtlFilteredPipelinesHonorDcRemoval() {
     auto disabled = FileSelector::make(std::vector<float>{ 1.0f }, false);
     auto enabled = FileSelector::make(std::vector<float>{ 1.0f }, true);
 
-    float disabledMagnitude = 0.0f;
-    float enabledMagnitude = 0.0f;
-    for (int sample = 0; sample < 2000; ++sample) {
-        disabledMagnitude = disabled.process(8.0f, -4.0f);
-        enabledMagnitude = enabled.process(8.0f, -4.0f);
+    int32_t disabledMagnitude = 0;
+    int32_t enabledMagnitude = 0;
+    for (int sample = 0; sample < 20000; ++sample) {
+        disabledMagnitude = disabled.process(8000, -4000);
+        enabledMagnitude = enabled.process(8000, -4000);
     }
 
     using BuiltInSelector = IQPipelineSelector<Rate_2_4_Mhz, Rate_8_0_Mhz,
         IQPipelineOptions::IQ_FIR_RTL_SDR>;
     const auto builtIn = BuiltInSelector::make({}, true);
 
-    return enabledMagnitude < disabledMagnitude * 0.001f
-        && builtIn.toString().find("[DCRemoval] alpha: 0.005")
+    return enabledMagnitude < disabledMagnitude / 1000
+        && builtIn.toString().find("[DCRemoval] alpha: 1/2048")
             != std::string::npos;
 }
 


### PR DESCRIPTION
## Summary

- add a `--dc-removal` option for using the existing DC-removal stage without enabling the FIR filter
- keep the existing Airspy `-q` and `-f` pipelines unchanged, since they already include DC removal
- honor `--dc-removal` when it is combined with RTL-SDR `-q` or `-f`
- document the option in `--help` and the README
- test enabled, disabled, and filtered RTL-SDR DC-removal behavior

## Motivation

Without `-q`, the plain IQ pipeline does not remove receiver DC offset before calculating magnitude. On the Airspy used for testing, the input sat about 7 LSB above the nominal center of its 12-bit range. Enabling DC removal recovered around 17% more messages at 6 → 24 Msps across two recorded captures.

This makes the useful part of the filtered pipeline available to systems that do not have enough CPU headroom for the FIR filter. The stage is runtime-gated in the plain pipeline instead of adding another preset dimension; the earlier measurement put that overhead at about 2%, while duplicating presets increased the binary by about 23%.

For consistency, an explicit `--dc-removal` is also passed through the RTL-SDR built-in and file-based FIR pipelines. It remains disabled there unless requested.

## Validation

- Release build with AppleClang
- `ctest --test-dir build-dc-rebase --output-on-failure`: 7/7 tests passed
- verified that `stream1090 --help` documents the new option
- exercised DC removal through the RTL-SDR built-in and pass-through file-filter selectors



## Follow-up correction

The branch is rebased onto the current fixed-point DC-removal implementation. RTL-SDR presets use the slower 1/2048 estimator (approximately alpha 0.0005), which avoids the excessive signal subtraction seen with alpha 0.005; Airspy retains the faster 1/256 estimator. The README explains the rate-specific choice, and the fixed-point tests cover enabled, disabled and filtered paths. Full local suite: 10/10.