### PR TITLE
Reject unknown ICAO addresses from an L1 bitmap

### DIFF
--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -85,19 +85,41 @@ public:
 	}
 
 	Iterator insertWithCA(uint32_t icaoWithCA) noexcept  {
-		const auto key = icaoWithCA & HashMask; 
+		const auto key = icaoWithCA & HashMask;
 		doResetEntry(key);
 		m_table[key].icao = icaoWithCA;
+		if (icaoWithCA != 0x0)
+			setOccupiedBit(key);
 		return Iterator(key);
 	}
 
+	/*
+	 * Both lookups below are on the demodulation hot path: every DF 0, 4, 5,
+	 * 16, 20 and 21 candidate reaches one of them, and on those the address is
+	 * recovered from the parity, so on noise the probe is a random index into
+	 * 65536 entries of 8 bytes. That table plus its two siblings is about
+	 * 1.4 MB against 1 MB of L2, so the probe usually goes to DRAM, and with a
+	 * few hundred live aircraft in 65536 slots it almost always says "no".
+	 *
+	 * m_occupiedBits mirrors "this slot holds an entry" in 8 KB, which stays in
+	 * L1. An empty slot has icao == 0, so a clear bit already settles the
+	 * comparison: it matches only a zero query. That makes this an exact
+	 * short circuit rather than a heuristic, and the table is never touched on
+	 * the rejecting path.
+	 */
 	Iterator findWithCA(uint32_t icaoWithCA) const noexcept {
-		const auto key = icaoWithCA & HashMask; 
+		const auto key = icaoWithCA & HashMask;
+		if (!isOccupied(key))
+			return (icaoWithCA == 0x0) ? Iterator(key) : Iterator();
+
 		return (m_table[key].icao == icaoWithCA) ? Iterator(key) : Iterator();
 	}
 
 	Iterator find(uint32_t icao) const noexcept {
-		const auto key = icao & HashMask; 
+		const auto key = icao & HashMask;
+		if (!isOccupied(key))
+			return (icao == 0x0) ? Iterator(key) : Iterator();
+
 		return ((m_table[key].icao & 0xffffffu) == icao) ? Iterator(key) : Iterator();
 	}
 
@@ -229,6 +251,22 @@ private:
 
 	std::array<uint64_t, Size / 64> m_trustedBits{};
 
+	// mirrors m_table[key].icao != 0, kept in step by insertWithCA and
+	// doResetEntry, the only two places that write the field
+	bool isOccupied(uint32_t key) const noexcept {
+		return (m_occupiedBits[key >> 6] >> (key & 63)) & 0x1;
+	}
+
+	void setOccupiedBit(uint32_t key) noexcept {
+		m_occupiedBits[key >> 6] |= (uint64_t(1) << (key & 63));
+	}
+
+	void clearOccupiedBit(uint32_t key) noexcept {
+		m_occupiedBits[key >> 6] &= ~(uint64_t(1) << (key & 63));
+	}
+
+	std::array<uint64_t, Size / 64> m_occupiedBits{};
+
 	void doTickForEntry(uint16_t index) noexcept {
 		auto& entry = m_table[index];
 		if (entry.icao == 0x0)
@@ -256,6 +294,7 @@ private:
 		entry.icao = 0x0;
 		entry.ttl_trusted = 0;
 		entry.ttl = 0;
+		clearOccupiedBit(index);
 		m_msgStatTable[index].last_time = 0;
 		m_squawkAlt[index] = SquawkAlt{0, 0, 0, 0};
 	}

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -51,10 +51,54 @@ bool hashCollisionsCannotConfirmAnotherAddress() {
     return !table.confirmDF11Candidate(first);
 }
 
+bool emptySlotsRejectUnknownAddresses() {
+    ICAOTable table;
+    constexpr uint32_t unknownWithCA = 0x5abcde1;
+
+    return !table.findWithCA(unknownWithCA).isValid()
+        && !table.find(unknownWithCA & 0xffffffu).isValid()
+        && table.findWithCA(0).isValid()
+        && table.find(0).isValid();
+}
+
+bool insertedAndReplacementEntriesAreFound() {
+    ICAOTable table;
+    constexpr uint32_t first = 0x1abcde;
+    constexpr uint32_t replacement = 0x2abcde;
+
+    table.insertWithCA(first);
+    if (!table.findWithCA(first).isValid() || !table.find(first).isValid())
+        return false;
+
+    table.insertWithCA(replacement);
+    return !table.findWithCA(first).isValid()
+        && !table.find(first).isValid()
+        && table.findWithCA(replacement).isValid()
+        && table.find(replacement).isValid();
+}
+
+bool expiredEntriesDisappear() {
+    ICAOTable table;
+    constexpr uint32_t icaoWithCA = 0x5000001;
+
+    const auto entry = table.insertWithCA(icaoWithCA);
+    table.markAsSeen(entry, 1);
+    tick(table, 1);
+    if (!table.findWithCA(icaoWithCA).isValid())
+        return false;
+
+    tick(table, 1'000'000);
+    return !table.findWithCA(icaoWithCA).isValid()
+        && !table.find(icaoWithCA & 0xffffffu).isValid();
+}
+
 } // namespace
 
 int main() {
     return !(confirmsOnlySeparateSightings()
         && expiresOldSightings()
-        && hashCollisionsCannotConfirmAnotherAddress());
+        && hashCollisionsCannotConfirmAnotherAddress()
+        && emptySlotsRejectUnknownAddresses()
+        && insertedAndReplacementEntriesAreFound()
+        && expiredEntriesDisappear());
 }


### PR DESCRIPTION
## Summary

- add an exact 8 KiB occupancy bitmap in front of the 512 KiB ICAO entry table
- reject empty slots from the L1-resident bitmap before issuing a random table lookup
- keep the bitmap synchronized on insertion, replacement, expiry, and reset
- preserve the existing zero-key lookup behavior
- add regression coverage for empty slots, insertion, same-slot replacement, and expiry

## Why

DF 0, 4, 5, 16, 20, and 21 candidates recover an ICAO address from parity and probe the cache. On noise, that address is effectively a random index into 65,536 entries. With only a few hundred live aircraft, nearly every probe misses, but the current code still reads the large entry table before discovering that the slot is empty.

The new bitmap mirrors `entry.icao != 0`. A clear bit is an exact negative result, not a probabilistic filter, so the large table is skipped on the common miss path without changing acceptance behavior.

## Raspberry Pi 4 benchmark

Measured on `rpi243`, a Raspberry Pi 4, using clean Release builds from current `origin/main` at `6f1480b` with statistics disabled. Both variants replayed the same 59.8-second Airspy U16-real capture at 6 Msps, demodulated at 24 MHz with the built-in FIR.

The node was running its normal production workload, so the comparison uses per-process `perf stat` counters rather than system CPU percentage or wall time. Runs were alternated baseline → bitmap → bitmap → baseline.

| Metric | Baseline mean | Bitmap mean | Difference |
| --- | ---: | ---: | ---: |
| task-clock | 69.808 s | 50.957 s | **-27.0%** |
| cycles | 104.184 G | 76.374 G | **-26.7%** |
| cache misses | 620.268 M | 337.275 M | **-45.6%** |
| instructions | 102.567 G | 103.702 G | +1.1% |

Individual task-clock results were 72.027 s and 67.588 s for the baseline, and 50.699 s and 51.215 s with the bitmap.

The replay output was byte-identical: 1,183,118 bytes with SHA-256 `8d2f7b627a1a4542dcb5420c7c169e2a7c74b4bdb0b55d789ae6c354384c884b` for both builds.

## Validation

- clean Release build with AppleClang
- local test suite: 5/5 passed
- ICAO cache tests cover empty rejection, zero-key compatibility, insertion, same-slot replacement, and expiry/reset
- byte-identical replay output on rpi243
