### PR TITLE
Multicore: make the staged pipeline deterministic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(stream1090)
 
+find_package(Threads REQUIRED)
+
 # ------------------------------------------------------------
 # Build type
 # ------------------------------------------------------------
@@ -137,7 +139,7 @@ target_compile_definitions(stream1090 PRIVATE
     ${DEVICE_DEFINITIONS}
 )
 
-target_link_libraries(stream1090 PRIVATE ${DEVICE_LIBS})
+target_link_libraries(stream1090 PRIVATE ${DEVICE_LIBS} Threads::Threads)
 
 include(CTest)
 if(BUILD_TESTING)
@@ -160,6 +162,12 @@ if(BUILD_TESTING)
     target_include_directories(ring_buffer_test PRIVATE include)
     target_compile_options(ring_buffer_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME ring_buffer_test COMMAND ring_buffer_test)
+
+    add_executable(block_ring_async_test tests/BlockRingAsyncTest.cpp)
+    target_include_directories(block_ring_async_test PRIVATE include)
+    target_compile_options(block_ring_async_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    target_link_libraries(block_ring_async_test PRIVATE Threads::Threads)
+    add_test(NAME block_ring_async_test COMMAND block_ring_async_test)
 endif()
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ situations, a higher overall message rate can be achieved compared to a preamble
 - Support for Airspy and RTL-SDR dongles.
 - Support for 6 or 10 Msps for Airspy and 2.4 or 2.56 Msps for RTL-SDR devices.
 - IQ Low-pass filtering including customization and optimization (optional).
+- Multicore pipeline overlapping input, upsampling, and demodulation.
 - Seamless integration into readsb/dump1090-fa based stacks.
 
 ## Requirements

--- a/include/AVRWriter.hpp
+++ b/include/AVRWriter.hpp
@@ -27,9 +27,7 @@ namespace hex_detail {
 
 class AVRWriter {
 public:
-    AVRWriter(std::ostream& out) : m_out(out) {
-        std::ios::sync_with_stdio(false);
-    }
+    explicit AVRWriter(std::ostream& out) : m_out(out) {}
 
     // Writes an AVR short frame with MLAT timestamp (no RSSI)
     void write_short_MLAT(uint64_t ts, uint64_t frameShort) {
@@ -117,6 +115,5 @@ private:
     // the stream to write ot
     std::ostream& m_out;
 };
-
 
 

--- a/include/BlockRingAsync.hpp
+++ b/include/BlockRingAsync.hpp
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 Martin Gronemann
+ *
+ * This file is part of stream1090 and is licensed under the GNU General
+ * Public License v3.0. See the top-level LICENSE file for details.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <thread>
+
+// A bounded single-producer/single-consumer ring. Each sequence is written by
+// only one thread and lives on its own cache line. HistoryBlocks slots stay
+// unavailable to the producer so the consumer may safely inspect old samples.
+template<typename T, size_t BlockSize, size_t NumBlocks, size_t Delay = 0,
+         size_t HistoryBlocks = 0>
+class BlockRingAsync {
+public:
+    static_assert(NumBlocks > HistoryBlocks);
+    static_assert(Delay <= BlockSize);
+
+    static constexpr size_t RingSize = BlockSize * NumBlocks;
+    static constexpr size_t TotalSize = RingSize + Delay;
+    static constexpr size_t Capacity = NumBlocks - HistoryBlocks;
+
+    explicit BlockRingAsync(const T& initValue)
+        : m_data(
+            new (std::align_val_t(CacheLineSize)) T[TotalSize],
+            AlignedDeleter{}
+        )
+    {
+        std::fill(m_data.get(), m_data.get() + TotalSize, initValue);
+    }
+
+    // Producer thread. Blocks until one slot is writable.
+    T* waitWritePos() noexcept {
+        const size_t writeSequence = publishedSequence();
+        for (;;) {
+            const size_t readSequence = m_readSequence.load(std::memory_order_acquire);
+            if (writeSequence - readSequence < Capacity)
+                break;
+            std::this_thread::sleep_for(RetryDelay);
+        }
+        return m_data.get() + Delay + (writeSequence % NumBlocks) * BlockSize;
+    }
+
+    // Producer thread. Publishes the block returned by waitWritePos().
+    void advanceWritePos() noexcept {
+        const size_t writeSequence = publishedSequence();
+        if constexpr (Delay > 0) {
+            if ((writeSequence % NumBlocks) == NumBlocks - 1) {
+                std::memcpy(m_data.get(),
+                            m_data.get() + RingSize,
+                            Delay * sizeof(T));
+            }
+        }
+
+        m_publishedState.store((writeSequence + 1) << 1, std::memory_order_release);
+    }
+
+    // Consumer thread. Returns null after the producer has finished and all
+    // published blocks have been consumed.
+    const T* waitReadPos() noexcept {
+        const size_t readSequence = m_readSequence.load(std::memory_order_relaxed);
+        for (;;) {
+            const size_t state = m_publishedState.load(std::memory_order_acquire);
+            if (readSequence < (state >> 1))
+                return m_data.get() + (readSequence % NumBlocks) * BlockSize;
+            if (state & FinishedBit)
+                return nullptr;
+            std::this_thread::sleep_for(RetryDelay);
+        }
+    }
+
+    // Consumer thread.
+    const T* readPos() const noexcept {
+        const size_t readSequence = m_readSequence.load(std::memory_order_relaxed);
+        return m_data.get() + (readSequence % NumBlocks) * BlockSize;
+    }
+
+    // Consumer thread.
+    void advanceReadPos() noexcept {
+        const size_t readSequence = m_readSequence.load(std::memory_order_relaxed);
+        m_readSequence.store(readSequence + 1, std::memory_order_release);
+    }
+
+    // Consumer thread.
+    const T& lookBack(size_t k, size_t offsetInBlock = 0) const noexcept {
+        const size_t readSequence = m_readSequence.load(std::memory_order_relaxed);
+        size_t absoluteIndex = (readSequence % NumBlocks) * BlockSize + offsetInBlock;
+        if (absoluteIndex >= RingSize)
+            absoluteIndex -= RingSize;
+
+        size_t lookBackIndex = absoluteIndex + RingSize - k;
+        if (lookBackIndex >= RingSize)
+            lookBackIndex -= RingSize;
+
+        return m_data[lookBackIndex];
+    }
+
+    // Producer thread.
+    void finished() noexcept {
+        const size_t writeSequence = publishedSequence();
+        m_publishedState.store((writeSequence << 1) | FinishedBit,
+                               std::memory_order_release);
+    }
+
+private:
+    static constexpr size_t CacheLineSize = 64;
+    static constexpr size_t FinishedBit = 1;
+    static constexpr auto RetryDelay = std::chrono::microseconds(100);
+
+    struct AlignedDeleter {
+        void operator()(T* p) const noexcept {
+            ::operator delete[](p, std::align_val_t(CacheLineSize));
+        }
+    };
+
+    size_t publishedSequence() const noexcept {
+        return m_publishedState.load(std::memory_order_relaxed) >> 1;
+    }
+
+    std::unique_ptr<T[], AlignedDeleter> m_data;
+    alignas(CacheLineSize) std::atomic<size_t> m_readSequence{0};
+    alignas(CacheLineSize) std::atomic<size_t> m_publishedState{0};
+};

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -397,9 +397,9 @@ private:
 	}
 	
 	// while dealing with a single stream, this holds a copy of the frame
-	// from the previous stream  
-	alignas(16) Bits128 m_prevLongFrame; 
-	alignas(16) uint64_t m_prevShortFrame; 
+	// from the previous stream
+	alignas(16) Bits128 m_prevLongFrame;
+	alignas(16) uint64_t m_prevShortFrame{ 0 };
 
 	// plane lookup table
 	ICAOTable m_cache; 

--- a/include/SampleStream.hpp
+++ b/include/SampleStream.hpp
@@ -9,128 +9,13 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
-#include <memory>
-#include <cstring>
 #include <algorithm>
+#include <thread>
 
+#include "BlockRingAsync.hpp"
 #include "DemodCore.hpp"
 #include "Sampler.hpp"
 #include "MessageHandler.hpp"
-
-// ------------------------------------------------------------
-// SPSC BlockRing
-// ------------------------------------------------------------
-template<typename T, size_t BlockSize, size_t NumBlocks, size_t Delay = 0, size_t NumHistoryBlocks = 0>
-class BlockRingAsync {
-public:
-    static constexpr size_t TotalSize = BlockSize * NumBlocks + Delay;
-
-    BlockRingAsync(const T& initValue)
-        : m_data(
-            new (std::align_val_t(16)) T[TotalSize],
-            AlignedDeleter{}
-        ),
-          m_readPos(0),
-          m_writePos(Delay),
-          m_fullBlocks(0),
-          m_finished(false)
-    {
-        std::fill(m_data.get(), m_data.get() + TotalSize, initValue);
-    }
-
-    // producer thread
-    T* writePos() noexcept {
-        return m_data.get() + m_writePos.load(std::memory_order_relaxed);
-    }
-
-    // producer thread
-    void advanceWritePos() noexcept {
-        size_t wp = m_writePos.load(std::memory_order_relaxed);
-        wp += BlockSize;
-
-        if (wp + BlockSize > TotalSize) {
-            if constexpr (Delay > 0) {
-                std::memcpy(
-                    m_data.get(),
-                    m_data.get() + (TotalSize - Delay),
-                    Delay * sizeof(T)
-                );
-            }
-            wp = Delay;
-        }
-
-        m_writePos.store(wp, std::memory_order_release);
-        m_fullBlocks.fetch_add(1, std::memory_order_release);
-    }
-
-    // consumer thread
-    const T* readPos() const noexcept {
-        return m_data.get() + m_readPos.load(std::memory_order_relaxed);
-    }
-
-    // consumer thread
-    void advanceReadPos() noexcept {
-        size_t rp = m_readPos.load(std::memory_order_relaxed);
-        rp += BlockSize;
-
-        if (rp >= BlockSize * NumBlocks) {
-            rp = 0;
-        }
-
-        m_readPos.store(rp, std::memory_order_release);
-        m_fullBlocks.fetch_sub(1, std::memory_order_release);
-    }
-
-    // consumer thread
-    bool isReadable() const noexcept {
-        return m_fullBlocks.load(std::memory_order_acquire) > 0;
-    }
-
-    // producer thread
-    bool isWritable() const noexcept {
-        return m_fullBlocks.load(std::memory_order_acquire) < NumBlocks - 1;
-    }
-
-    // consumer thread
-    const T& lookBack(size_t k, size_t offsetInBlock = 0) const noexcept {
-        size_t rp = m_readPos.load(std::memory_order_relaxed);
-        size_t absoluteIndex = rp + offsetInBlock;
-        if (absoluteIndex >= TotalSize)
-            absoluteIndex -= TotalSize;
-
-        size_t lookBackIndex = absoluteIndex + TotalSize - k;
-        if (lookBackIndex >= TotalSize)
-            lookBackIndex -= TotalSize;
-
-        return m_data[lookBackIndex];
-    }
-
-    // consumer thread
-    bool eof() const noexcept {
-        return m_finished.load(std::memory_order_acquire) &&
-               (m_fullBlocks.load(std::memory_order_acquire) == 0);
-    }
-
-    // producer thread
-    void finished() noexcept {
-        m_finished.store(true, std::memory_order_release);
-    }
-
-private:
-    struct AlignedDeleter {
-        void operator()(T* p) const noexcept {
-            ::operator delete[](p, std::align_val_t(16));
-        }
-    };
-
-    std::unique_ptr<T[], AlignedDeleter> m_data;
-
-    std::atomic<size_t> m_readPos;
-    std::atomic<size_t> m_writePos;
-    std::atomic<size_t> m_fullBlocks;
-    std::atomic<bool>   m_finished;
-};
 
 // the main stream class. This class manages reading from the input stream
 // and also manages the buffers
@@ -172,9 +57,11 @@ public:
 private:
     uint32_t m_newBits[Sampler::NumStreams];    
     // we have one ring buffer for the IQ pipeline
-    BlockRingAsync<float, Sampler::InputBufferSize,  NumInputBuffers,  Sampler::InputBufferOverlap>  m_inputRingBuffer;
+    BlockRingAsync<float, Sampler::InputBufferSize, NumInputBuffers,
+                   Sampler::InputBufferOverlap, 1> m_inputRingBuffer;
     // and one for the upsampled magnitudes
-    BlockRingAsync<float, Sampler::SampleBufferSize, NumSampleBuffers, Sampler::SampleBufferOverlap> m_sampleRingBuffer;
+    BlockRingAsync<float, Sampler::SampleBufferSize, NumSampleBuffers,
+                   Sampler::SampleBufferOverlap, 1> m_sampleRingBuffer;
     // not nice. Will change
     const float* m_demodPos = nullptr;
 };
@@ -185,48 +72,42 @@ template<typename InputReaderType, MessageHandler Handler>
 inline void SampleStream<Sampler>::read(InputReaderType& inputReader, Handler& messageHandler) {  
     DemodCore<Sampler::NumStreams, Handler> demodCore(messageHandler);
 
-    std::thread helperThreadA([&]{ 
-        while (!inputReader.eof()) {
-            // check if we can write to the input buffer
-            if (!m_inputRingBuffer.isWritable()) {
-                //std::this_thread::yield();
-                std::this_thread::sleep_for(std::chrono::microseconds(200));
-                continue;
+    std::jthread inputThread;
+    std::jthread samplerThread;
+
+    if constexpr (Sampler::isPassthrough) {
+        static_assert(Sampler::NumBlocks == Sampler::InputBufferSize);
+        inputThread = std::jthread([&] {
+            while (!inputReader.eof()) {
+                float* output = m_sampleRingBuffer.waitWritePos();
+                inputReader.readMagnitude(output);
+                m_sampleRingBuffer.advanceWritePos();
             }
-
-            inputReader.readMagnitude(m_inputRingBuffer.writePos());
-            m_inputRingBuffer.advanceWritePos();
-        }
-        m_inputRingBuffer.finished();
-    });
-
-    std::thread helperThreadB([&]{ 
-        while (!m_inputRingBuffer.eof()) {
-            // check if we can write to the samplebuffer and read from inputbuffer
-            if (!m_sampleRingBuffer.isWritable() || !m_inputRingBuffer.isReadable()) {
-                std::this_thread::sleep_for(std::chrono::microseconds(200));
-                continue;
+            m_sampleRingBuffer.finished();
+        });
+    } else {
+        inputThread = std::jthread([&] {
+            while (!inputReader.eof()) {
+                float* output = m_inputRingBuffer.waitWritePos();
+                inputReader.readMagnitude(output);
+                m_inputRingBuffer.advanceWritePos();
             }
+            m_inputRingBuffer.finished();
+        });
 
-            Sampler::sample(m_inputRingBuffer.readPos(),
-                            m_sampleRingBuffer.writePos());
-
-            m_inputRingBuffer.advanceReadPos();
-            m_sampleRingBuffer.advanceWritePos();
-        }
-        m_sampleRingBuffer.finished();
-    });
+        samplerThread = std::jthread([&] {
+            while (const float* input = m_inputRingBuffer.waitReadPos()) {
+                float* output = m_sampleRingBuffer.waitWritePos();
+                Sampler::sample(input, output);
+                m_inputRingBuffer.advanceReadPos();
+                m_sampleRingBuffer.advanceWritePos();
+            }
+            m_sampleRingBuffer.finished();
+        });
+    }
         
     // main thread
-    while (!m_sampleRingBuffer.eof()) {
-        // check if we can read from the sample buffer
-        if (!m_sampleRingBuffer.isReadable()) {
-            std::this_thread::sleep_for(std::chrono::microseconds(200));
-            continue;
-        }
-
-        m_demodPos = m_sampleRingBuffer.readPos();
-
+    while ((m_demodPos = m_sampleRingBuffer.waitReadPos())) {
         for (size_t i = 0; i < Sampler::SampleBufferSize; i += Sampler::NumStreams) {
             for (size_t j = 0; j < Sampler::NumStreams; j++) {
                 m_newBits[j] = m_demodPos[j] > m_demodPos[j + (Sampler::NumStreams >> 1)];
@@ -237,7 +118,4 @@ inline void SampleStream<Sampler>::read(InputReaderType& inputReader, Handler& m
 
         m_sampleRingBuffer.advanceReadPos();
     }
-
-    helperThreadA.join();
-    helperThreadB.join();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -263,6 +263,12 @@ std::vector<float> load_taps_from_file(const std::string& filename) {
 }
 
 int main(int argc, char** argv) {
+    // Input and logging may run beside AVR output. Their default ties must not
+    // flush std::cout concurrently from another thread.
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+    std::cerr.tie(nullptr);
+
     RuntimeVars r_vars;
     CompileTimeVars c_vars;
 
@@ -415,8 +421,6 @@ int main(int argc, char** argv) {
     }
     return *outcome ? 0 : 1;
 }
-
-
 
 
 

--- a/tests/BlockRingAsyncTest.cpp
+++ b/tests/BlockRingAsyncTest.cpp
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "BlockRingAsync.hpp"
+
+#include <cstdlib>
+#include <thread>
+
+namespace {
+
+void require(bool condition) {
+    if (!condition)
+        std::abort();
+}
+
+void testConcurrentWraparoundAndHistory() {
+    constexpr size_t BlockSize = 8;
+    constexpr size_t Delay = 2;
+    constexpr size_t NumValues = 200000;
+    constexpr size_t NumBlocks = NumValues / BlockSize;
+    using Ring = BlockRingAsync<int, BlockSize, 4, Delay, 1>;
+
+    Ring ring(-1);
+
+    std::jthread producer([&] {
+        for (size_t block = 0; block < NumBlocks; ++block) {
+            int* output = ring.waitWritePos();
+            for (size_t i = 0; i < BlockSize; ++i)
+                output[i] = int(block * BlockSize + i);
+            ring.advanceWritePos();
+            if ((block & 31) == 0)
+                std::this_thread::yield();
+        }
+        ring.finished();
+    });
+
+    size_t block = 0;
+    while (const int* input = ring.waitReadPos()) {
+        for (size_t i = 0; i < Delay; ++i) {
+            const int expected = block == 0
+                ? -1
+                : int(block * BlockSize - Delay + i);
+            require(input[i] == expected);
+        }
+        for (size_t i = 0; i < BlockSize; ++i)
+            require(input[Delay + i] == int(block * BlockSize + i));
+
+        if (block > 0)
+            require(ring.lookBack(1, Delay) == int(block * BlockSize - 1));
+        if (block > 0 && block % 4 == 0)
+            require(ring.lookBack(1, 0) == int(block * BlockSize - Delay - 1));
+
+        ring.advanceReadPos();
+        if ((block & 15) == 0)
+            std::this_thread::yield();
+        ++block;
+    }
+
+    require(block == NumBlocks);
+}
+
+void testFinishWakesEmptyConsumer() {
+    BlockRingAsync<int, 1, 2> ring(0);
+    std::jthread producer([&] {
+        std::this_thread::yield();
+        ring.finished();
+    });
+    require(ring.waitReadPos() == nullptr);
+}
+
+} // namespace
+
+int main() {
+    testConcurrentWraparoundAndHistory();
+    testFinishWakesEmptyConsumer();
+}


### PR DESCRIPTION
## Summary

This draft builds on the initial three-stage implementation in the `multicore` branch. It keeps the same input → upsampler → demodulator design, while tightening the SPSC handoff, restoring the passthrough fast path, and fixing the nondeterministic output observed during replay.

## Changes

- replace the shared read/write/full-block state with producer- and consumer-owned sequence counters on separate cache lines;
- retain one history block explicitly so RSSI lookback remains valid while the producer advances;
- use the logical ring length for lookback wrapping, rather than the allocation length including overlap;
- centralize the measured 100 µs retry delay in the ring and remove the 200 µs polling loops from `SampleStream`;
- keep passthrough samplers on a two-stage path instead of invoking the upsampler unnecessarily;
- use `std::jthread` for scoped joins and link the platform thread target explicitly;
- untie stdin and stderr from stdout before starting worker threads;
- initialize the previous short frame used by phase deduplication;
- add a concurrent wraparound/history/EOF regression test and document the multicore pipeline.

## Root cause of the duplicate output

The input worker reads from `std::cin`, which is tied to `std::cout` by default. Each binary read could therefore flush AVR output concurrently with the demodulation thread. With unsynchronized standard streams this occasionally emitted an adjacent copy of an already-written line. The demodulator itself produced the expected 34,221 messages; the output file contained additional nondeterministic copies.

The RSSI differences at block boundaries had a separate cause: `lookBack()` wrapped by `BlockSize * NumBlocks + Delay`. The overlap is allocation space, not part of the logical ring, so wrapped history was shifted by 12 samples in the 6 → 24 MHz preset.

## Raspberry Pi 5 replay

Test input: the same 59.965 s Airspy Mini capture at 6 Msps, replayed at 6 → 24 MHz with the built-in FIR, Release build, statistics disabled, pinned to cores 1–3.

| Version | Wall time | Aggregate CPU | Output |
| --- | ---: | ---: | --- |
| synchronous base | 19.83 s | 19.81 s | 34,221 deterministic messages |
| initial `multicore` branch | 13.43–13.50 s | 20.07–20.18 s | 34,369–34,396 lines, varying between runs |
| this draft | 13.25–13.41 s | 19.96–20.11 s | 34,221 deterministic messages |

The final output is byte-identical across repeated runs (`57d457957a49299db9e3a347c01476a1ece68bca03cac200f59f4d6fc5987cf1`). It is also byte-identical to the synchronous pipeline when the same logical-ring lookback correction is applied there, including RSSI.

## Validation

- full CTest suite on macOS and Raspberry Pi 5;
- concurrent ring test covering wraparound, retained history and EOF wakeup;
- ring test under ThreadSanitizer;
- repeated full-capture replay and byte-for-byte output comparison.

This targets `multicore` intentionally so the draft shows only the optimizations on top of the initial work. Rebasing or porting the design to current `main`, including its newer confidence/history requirements, should be handled before merging it into `main`.
