### PR TITLE
Decode Gillham Q=0 altitude replies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,11 @@ if(BUILD_TESTING)
     target_include_directories(sampler_test PRIVATE include)
     target_compile_options(sampler_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME sampler_test COMMAND sampler_test)
+
+    add_executable(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
+    target_include_directories(mode_s_altitude_test PRIVATE include)
+    target_compile_options(mode_s_altitude_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME mode_s_altitude_test COMMAND mode_s_altitude_test)
 endif()
 
 # ------------------------------------------------------------

--- a/README_ADV.md
+++ b/README_ADV.md
@@ -78,6 +78,12 @@ For ```airspy_rx``` this works the same way. However, make sure that your sample
 
 When changing the CRC correction patterns, build and run the `table_gen` target to confirm the declared pattern count. The advanced table uses open addressing to preserve colliding entries. Then run CTest: `crc_error_table_test` verifies that every declared DF17 and DF11 correction remains reachable from its CRC syndrome.
 
+Altitude replies support both Q=1 binary encoding in 25-foot increments and
+Q=0 Gillham/Mode C encoding in 100-foot increments. Metric M=1 altitude
+encoding is currently treated as unavailable. Gillham values are checked
+against an altitude already established by Q=1 replies and cannot replace that
+reference value.
+
 DF11 all-call replies may overlay the CRC parity with a non-zero II/SI interrogator code. Stream1090 accepts these replies for known aircraft. A new ICAO address is added to the cache only after two matching DF11 replies separated in time, so phase duplicates or a single low CRC syndrome cannot seed the cache.
 
 Important: If you want to see the statistics for the whole file and not every 5 seconds. You can enable the a summary at the end by rebuilding stream with after the following cmake call in the build directory

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -84,7 +84,7 @@ public:
 		if ((downlinkFormat == 20) || (downlinkFormat == 16)) {
 			const auto alt_bits = ModeS::extractSquawkAlt_Long(frame);
 			const auto alt = ModeS::decodeAltitude(alt_bits);
-			if (!m_cache.checkAltitude(it, alt)) {	
+			if (!alt || !m_cache.checkAltitude(it, *alt, alt_bits & 0x0010)) {
 				return false;
 			} else {
 				m_cache.markAsSeen(it);
@@ -116,7 +116,7 @@ public:
 		if ((downlinkFormat == 4) || (downlinkFormat == 0)) {
 			const auto alt_bits = ModeS::extractSquawkAlt_Short(frameShort);
 			const auto alt = ModeS::decodeAltitude(alt_bits);
-			if (!m_cache.checkAltitude(it, alt)) {
+			if (!alt || !m_cache.checkAltitude(it, *alt, alt_bits & 0x0010)) {
 				return false;
 			} else {
 				m_cache.markAsSeen(it);

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <array>
+#include <cstdlib>
 #include <memory>
 
 class ICAOTable {
@@ -53,7 +54,7 @@ public:
 
 		// the last altitude in feet received
 		uint8_t altitude_cnt;
-		uint16_t altitude;
+		int16_t altitude_25ft;
 	};
 
     // simple struct keeping an index
@@ -208,22 +209,27 @@ public:
 		return false;
 	}
 
-	bool checkAltitude(const Iterator& entry, uint16_t newAlt) noexcept {
-		if (newAlt == 0) {
+	bool checkAltitude(const Iterator& entry, int32_t newAlt, bool updateState = true) noexcept {
+		auto& state = m_squawkAlt[entry.key];
+		if (!updateState && state.altitude_cnt == 0)
 			return false;
-		}
 
-		const auto delta = abs((int)m_squawkAlt[entry.key].altitude - (int)newAlt);
+		const auto delta = std::abs((int32_t)state.altitude_25ft * 25 - newAlt);
 		if ((delta <= ALT_delta_ft)) {
-			m_squawkAlt[entry.key].altitude = newAlt;
-			m_squawkAlt[entry.key].altitude_cnt = 1;
+			if (updateState) {
+				state.altitude_25ft = newAlt / 25;
+				state.altitude_cnt = 1;
+			}
 			return true;
 		};
 
-		if (m_squawkAlt[entry.key].altitude_cnt == 0) {
-			m_squawkAlt[entry.key].altitude = newAlt;
+		if (!updateState)
+			return false;
+
+		if (state.altitude_cnt == 0) {
+			state.altitude_25ft = newAlt / 25;
 		} else {
-			m_squawkAlt[entry.key].altitude_cnt = 0;
+			state.altitude_cnt = 0;
 		}
 		return false;
 	}

--- a/include/ModeS.hpp
+++ b/include/ModeS.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <iomanip>
 #include <chrono>
+#include <optional>
 
 namespace ModeS {
 
@@ -44,32 +45,67 @@ namespace ModeS {
 		return a * 1000 + b * 100 + c * 10 + d;
 	}
 
-	constexpr inline uint16_t decodeAltitudeBitsFeet(uint16_t bits) {
+	constexpr inline int32_t decodeAltitudeBitsFeet(uint16_t bits) {
 		const uint16_t a = (bits & 0xf); // lower 4 bits
 		const uint16_t b = (bits >> 5) & 0x1; // 6th bit
 		const uint16_t c = (bits >> 7) & 0x3f; // higher 6 bits
 		return (a | (b << 4) | (c << 5)) * 25 - 1000;
 	}
 
-	constexpr inline uint16_t decodeAltitudeBitsMeter(uint16_t bits) {
-		const uint16_t a = (bits & 0x3f); // lower 6 bits
-		const uint16_t b = (bits >> 7) & 0x3f; // higher 6 bits
-		return uint16_t(float(a | (b << 6))*3.28084f);
+	constexpr inline uint16_t decodeGillhamID13(uint16_t bits) {
+		uint16_t modeA = 0;
+		if (bits & 0x1000) modeA |= 0x0010; // C1
+		if (bits & 0x0800) modeA |= 0x1000; // A1
+		if (bits & 0x0400) modeA |= 0x0020; // C2
+		if (bits & 0x0200) modeA |= 0x2000; // A2
+		if (bits & 0x0100) modeA |= 0x0040; // C4
+		if (bits & 0x0080) modeA |= 0x4000; // A4
+		if (bits & 0x0020) modeA |= 0x0100; // B1
+		if (bits & 0x0010) modeA |= 0x0001; // D1 / Q
+		if (bits & 0x0008) modeA |= 0x0200; // B2
+		if (bits & 0x0004) modeA |= 0x0002; // D2
+		if (bits & 0x0002) modeA |= 0x0400; // B4
+		if (bits & 0x0001) modeA |= 0x0004; // D4
+		return modeA;
 	}
 
-	constexpr inline uint16_t decodeAltitude(uint16_t bits) {
-		// TODO: test this 
-		//check if the M bit is set and we have to deal with meters
-		/*if (bits & (0x1 << 6)) {
-			return decodeAltitudeBitsMeter(bits);
-		} else if (bits & (0x1 << 4)) {
-			return decodeAltitudeBitsFeet(bits);
-		}*/
+	constexpr inline std::optional<int32_t> decodeGillhamAltitude(uint16_t bits) {
+		const uint16_t modeA = decodeGillhamID13(bits);
+		if ((modeA & 0x8889) != 0 || (modeA & 0x00f0) == 0)
+			return std::nullopt;
 
-		if (!(bits & (0x1 << 6)) && (bits & (0x1 << 4)))
+		uint16_t oneHundreds = 0;
+		uint16_t fiveHundreds = 0;
+		if (modeA & 0x0010) oneHundreds ^= 0x007;
+		if (modeA & 0x0020) oneHundreds ^= 0x003;
+		if (modeA & 0x0040) oneHundreds ^= 0x001;
+		if ((oneHundreds & 5) == 5) oneHundreds ^= 2;
+		if (oneHundreds > 5)
+			return std::nullopt;
+
+		if (modeA & 0x0002) fiveHundreds ^= 0x0ff;
+		if (modeA & 0x0004) fiveHundreds ^= 0x07f;
+		if (modeA & 0x1000) fiveHundreds ^= 0x03f;
+		if (modeA & 0x2000) fiveHundreds ^= 0x01f;
+		if (modeA & 0x4000) fiveHundreds ^= 0x00f;
+		if (modeA & 0x0100) fiveHundreds ^= 0x007;
+		if (modeA & 0x0200) fiveHundreds ^= 0x003;
+		if (modeA & 0x0400) fiveHundreds ^= 0x001;
+		if (fiveHundreds & 1) oneHundreds = 6 - oneHundreds;
+
+		const int32_t hundreds = fiveHundreds * 5 + oneHundreds - 13;
+		if (hundreds < -12)
+			return std::nullopt;
+		return hundreds * 100;
+	}
+
+	constexpr inline std::optional<int32_t> decodeAltitude(uint16_t bits) {
+		if (bits & 0x0040) // M=1: metric encoding is not implemented.
+			return std::nullopt;
+
+		if (bits & 0x0010)
 			return decodeAltitudeBitsFeet(bits);
-		
-		return 0;
+		return decodeGillhamAltitude(bits);
 	}
 	
 	inline uint64_t currentTimestamp() {

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -92,6 +92,25 @@ bool expiredEntriesDisappear() {
         && !table.find(icaoWithCA & 0xffffffu).isValid();
 }
 
+bool validationOnlyAltitudeCannotPoisonState() {
+    ICAOTable table;
+    const auto entry = table.insertWithCA(0x5abcde1);
+
+    if (table.checkAltitude(entry, 0, false))
+        return false;
+    if (table.checkAltitude(entry, 10000, false))
+        return false;
+    if (table.checkAltitude(entry, 10000))
+        return false;
+    if (!table.checkAltitude(entry, 10000))
+        return false;
+    if (!table.checkAltitude(entry, 10500, false))
+        return false;
+    if (table.checkAltitude(entry, 13000, false))
+        return false;
+    return table.checkAltitude(entry, 10000);
+}
+
 } // namespace
 
 int main() {
@@ -100,5 +119,6 @@ int main() {
         && hashCollisionsCannotConfirmAnotherAddress()
         && emptySlotsRejectUnknownAddresses()
         && insertedAndReplacementEntriesAreFound()
-        && expiredEntriesDisappear());
+        && expiredEntriesDisappear()
+        && validationOnlyAltitudeCannotPoisonState());
 }

--- a/tests/ModeSAltitudeTest.cpp
+++ b/tests/ModeSAltitudeTest.cpp
@@ -1,0 +1,26 @@
+#include "ModeS.hpp"
+
+namespace {
+
+bool decodesTo(uint16_t bits, int32_t expected) {
+    const auto altitude = ModeS::decodeAltitude(bits);
+    return altitude && *altitude == expected;
+}
+
+} // namespace
+
+int main() {
+    // Q=1 binary encoding, including a valid negative altitude.
+    if (!decodesTo(0x0010, -1000)) return 1;
+    if (!decodesTo(0x06b8, 10000)) return 2;
+
+    // Q=0 Gillham / Mode C encoding.
+    if (!decodesTo(0x0100, -1200)) return 3;
+    if (!decodesTo(0x040a, 0)) return 4;
+    if (!decodesTo(0x06a2, 10000)) return 5;
+    if (!decodesTo(0x0e8b, 40000)) return 6;
+
+    if (ModeS::decodeAltitude(0x0000)) return 7; // Invalid Gillham code.
+    if (ModeS::decodeAltitude(0x0040)) return 8; // M=1 is not implemented.
+    return 0;
+}


### PR DESCRIPTION
## Summary

- decode Q=0 Gillham/Mode C altitude replies in addition to the existing Q=1 binary encoding
- represent unavailable altitude explicitly, preserving valid zero and negative altitudes
- accept Gillham values only when they agree with altitude state previously established by Q=1 replies, so Q=0 cannot seed or poison the plausibility cache
- keep the cache footprint unchanged by storing the signed reference altitude in 25-foot units
- document Q=0/Q=1 behavior and the currently unsupported metric M=1 encoding

## Motivation

Stream1090 previously treated every Q=0 altitude reply as unavailable. This caused otherwise valid altitude-bearing replies, particularly DF16 and DF20, to be rejected by the cache plausibility check.

The implementation is intentionally conservative: Gillham altitude can corroborate existing state but cannot update it.

## Validation

- all 7 CTest executables pass
- all 8,192 possible AC13 values match dump1090-fa's `modeAToModeC()` result, including invalid encodings
- the 90-second common `rpi243` replay increases DF16 from 185 to 186 and total output from 20,147 to 20,148, with no losses in other DFs
- `sizeof(ICAOTable::SquawkAlt)` remains 6 bytes (384 KiB for the complete table)
- alternating replay benchmark: 14.138 s CPU on `origin/main` versus 14.150 s with this change (+0.088%, within measurement noise)

