### PR TITLE
Fix 2.56 to 8 MHz interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ if(BUILD_TESTING)
     target_include_directories(erasure_repair_test PRIVATE include)
     target_compile_options(erasure_repair_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
     add_test(NAME erasure_repair_test COMMAND erasure_repair_test)
+
+    add_executable(sampler_test tests/SamplerTest.cpp)
+    target_include_directories(sampler_test PRIVATE include)
+    target_compile_options(sampler_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME sampler_test COMMAND sampler_test)
 endif()
 
 # ------------------------------------------------------------

--- a/include/Sampler.hpp
+++ b/include/Sampler.hpp
@@ -222,12 +222,12 @@ inline void SamplerBase<Rate_2_56_Mhz, Rate_8_0_Mhz>::sample(const float* __rest
             for (int j = 0; j < 25; j++) {
                 const auto offset = 8 * j;
                 const auto k = offset / 25;
-                const auto l = 24 - (offset % 25);
-                const auto r = 24 - l;
-                out[j] = ((float)l * in[k] + (float)r * in[k+1]) * (1.0f / 24.0f);
+                const auto l = 25 - (offset % 25);
+                const auto r = 25 - l;
+                out[j] = ((float)l * in[k] + (float)r * in[k+1]) * (1.0f / 25.0f);
             }
-            in += 8;//5;
-            out += 25;//12;
+            in += 8;
+            out += 25;
         }
 }
 

--- a/tests/SamplerTest.cpp
+++ b/tests/SamplerTest.cpp
@@ -1,0 +1,22 @@
+#include "Sampler.hpp"
+
+#include <cmath>
+#include <vector>
+
+int main() {
+    using Sampler = Sampler_2_56_to_8_0_Mhz;
+
+    std::vector<float> input(Sampler::InputBufferSize + Sampler::InputBufferOverlap);
+    std::vector<float> output(Sampler::SampleBufferSize);
+    for (size_t i = 0; i < input.size(); ++i)
+        input[i] = static_cast<float>(i);
+
+    Sampler::sample(input.data(), output.data());
+
+    for (size_t i = 0; i < output.size(); ++i) {
+        const float expected = static_cast<float>(i) * 8.0f / 25.0f;
+        if (std::fabs(output[i] - expected) > 2e-3f)
+            return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- use the correct denominator and complementary weights for 2.56 MHz to 8 MHz linear interpolation
- remove stale pointer-increment comments
- add a regression test covering the complete sampler buffer

## Root cause

The conversion ratio is 8 input samples to 25 output samples. The specialized sampler computed the input index with denominator 25, but calculated interpolation weights with denominator 24. This placed output samples at `remainder / 24` instead of `remainder / 25` of the interval between adjacent input samples.

## Validation

- the new ramp test fails on `origin/main` and passes with this change
- all 6 CTest executables pass
