### PR TITLE
Recover corroborated address-parity replies

### DIFF
--- a/README_ADV.md
+++ b/README_ADV.md
@@ -86,6 +86,8 @@ reference value.
 
 DF11 all-call replies may overlay the CRC parity with a non-zero II/SI interrogator code. Stream1090 accepts these replies for known aircraft. A new ICAO address is added to the cache only after two matching DF11 replies separated in time, so phase duplicates or a single low CRC syndrome cannot seed the cache.
 
+For DF0/4/5/16/20/21 address-parity replies, altitude and squawk checks normally reject implausible values. A rejected frame from an already active ICAO address is nevertheless accepted after the identical complete frame is received again between 100 microseconds and two seconds later. The first observation is withheld, short and long frames cannot confirm each other, and cache collisions can only discard a candidate. Corroborated Gillham or unsupported metric altitude replies do not update the stored altitude reference.
+
 Important: If you want to see the statistics for the whole file and not every 5 seconds. You can enable the a summary at the end by rebuilding stream with after the following cmake call in the build directory
 ```
 cmake ../ --fresh -DEND_STATS=ON -DENABLE_STATS=ON && make
@@ -191,7 +193,6 @@ One thing that is important to know is that you can also use a complete log file
 So it remains the question when the script terminates. Currently it does not. If there is no new solution after some time, you can stop it with Ctrl+c. If you are not happy with the results, you can restart it and resume from the log file and hope for some luck. You may want to increase the margin then a bit.
 
 **ATTENTION** The above description is a very sloppy one. Everything is subject to change. This includes the scoring function and additional parameters. If you want to use the optimizer, always check this section for any remarks first.
-
 
 
 

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -70,7 +70,7 @@ public:
 
 	bool sendFrameLongAligned(int,
 							  const uint8_t downlinkFormat, 
-							  CRC::crc_t, 
+							  CRC::crc_t crc,
 							  const Bits128& frame, 
 							  const ICAOTable::Iterator& it) {
 		auto& e = m_cache.getMsgStatEntry(it);
@@ -84,16 +84,19 @@ public:
 		if ((downlinkFormat == 20) || (downlinkFormat == 16)) {
 			const auto alt_bits = ModeS::extractSquawkAlt_Long(frame);
 			const auto alt = ModeS::decodeAltitude(alt_bits);
-			if (!alt || !m_cache.checkAltitude(it, *alt, alt_bits & 0x0010)) {
+			const bool altitudeAccepted = alt
+				&& m_cache.checkAltitude(it, *alt, alt_bits & 0x0010);
+			if (!altitudeAccepted
+					&& !m_cache.confirmRejectedLong(crc, frame.high(), frame.low())) {
 				return false;
-			} else {
-				m_cache.markAsSeen(it);
 			}
+			m_cache.markAsSeen(it);
 		}
 		
 		if (downlinkFormat == 21) {
 			const auto sqwk = ModeS::extractSquawkAlt_Long(frame);
-			if (!m_cache.checkSquawk(it, sqwk))
+			if (!m_cache.checkSquawk(it, sqwk)
+					&& !m_cache.confirmRejectedLong(crc, frame.high(), frame.low()))
 				return false;
 			m_cache.markAsSeen(it);
 		}
@@ -104,7 +107,7 @@ public:
 		return true;
 	}
 
-	bool sendFrameShortAligned(int, const uint8_t downlinkFormat, CRC::crc_t, const uint64_t& frameShort, const ICAOTable::Iterator& it) {
+	bool sendFrameShortAligned(int, const uint8_t downlinkFormat, CRC::crc_t crc, const uint64_t& frameShort, const ICAOTable::Iterator& it) {
 		auto& e = m_cache.getMsgStatEntry(it);
 		static constexpr uint64_t DUP_WINDOW_TICKS = 30 * NumStreams;
 		if ((m_currTime - e.last_time) < DUP_WINDOW_TICKS) {
@@ -116,16 +119,19 @@ public:
 		if ((downlinkFormat == 4) || (downlinkFormat == 0)) {
 			const auto alt_bits = ModeS::extractSquawkAlt_Short(frameShort);
 			const auto alt = ModeS::decodeAltitude(alt_bits);
-			if (!alt || !m_cache.checkAltitude(it, *alt, alt_bits & 0x0010)) {
+			const bool altitudeAccepted = alt
+				&& m_cache.checkAltitude(it, *alt, alt_bits & 0x0010);
+			if (!altitudeAccepted
+					&& !m_cache.confirmRejectedShort(crc, frameShort)) {
 				return false;
-			} else {
-				m_cache.markAsSeen(it);
 			}
+			m_cache.markAsSeen(it);
 		}
 
 		if (downlinkFormat == 5) {
 			const auto sqwk = ModeS::extractSquawkAlt_Short(frameShort);
-			if (!m_cache.checkSquawk(it, sqwk))
+			if (!m_cache.checkSquawk(it, sqwk)
+					&& !m_cache.confirmRejectedShort(crc, frameShort))
 				return false;
 			m_cache.markAsSeen(it);
 		}

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -19,6 +19,9 @@ public:
 	// detections of the same transmission while two seconds keeps the pair local.
 	static constexpr uint32_t DF11CandidateMinTicks { 100 };
 	static constexpr uint32_t DF11CandidateMaxTicks { 2'000'000 };
+	// Apply the same separation limits when corroborating rejected AP frames.
+	static constexpr uint32_t RejectedCandidateMinTicks { 100 };
+	static constexpr uint32_t RejectedCandidateMaxTicks { 2'000'000 };
 	//static constexpr auto ALT_delta_25ft { 80 };
 	static constexpr auto ALT_delta_ft { 2000 };
     // number if bits used for the look up table 
@@ -141,6 +144,14 @@ public:
 		return false;
 	}
 
+	bool confirmRejectedShort(uint32_t icao, uint64_t frame) noexcept {
+		return confirmRejectedFrame(icao, 0, frame, 56);
+	}
+
+	bool confirmRejectedLong(uint32_t icao, uint64_t high, uint64_t low) noexcept {
+		return confirmRejectedFrame(icao, high, low, 112);
+	}
+
 	void tick() noexcept {
 		m_df11Clock++;
 		
@@ -238,6 +249,39 @@ public:
 		return m_msgStatTable[it.key];
 	}
 private:
+	struct RejectedFrameCandidate {
+		uint64_t high { 0 };
+		uint64_t low { 0 };
+		uint64_t firstSeen { 0 };
+		uint32_t icao { 0 };
+		uint8_t bits { 0 };
+	};
+
+	static constexpr size_t RejectedCandidateCount { 2048 };
+
+	// Full-frame identity makes confirmation exact. This is direct-mapped so a
+	// collision can replace a candidate, but can never confirm a different one.
+	bool confirmRejectedFrame(uint32_t icao, uint64_t high, uint64_t low,
+			uint8_t bits) noexcept {
+		const uint64_t mixed = low ^ (high * 0x9e3779b97f4a7c15ull)
+			^ (uint64_t(icao) * 0xbf58476d1ce4e5b9ull);
+		auto& candidate = m_rejectedCandidates[mixed & (RejectedCandidateCount - 1)];
+		const auto age = m_df11Clock - candidate.firstSeen;
+
+		if (candidate.bits == bits && candidate.icao == icao
+				&& candidate.high == high && candidate.low == low) {
+			if (age >= RejectedCandidateMinTicks && age <= RejectedCandidateMaxTicks) {
+				candidate.firstSeen = m_df11Clock;
+				return true;
+			}
+			if (age < RejectedCandidateMinTicks)
+				return false;
+		}
+
+		candidate = RejectedFrameCandidate{high, low, m_df11Clock, icao, bits};
+		return false;
+	}
+
 	struct DF11Candidate {
 		uint32_t icaoWithCA { 0 };
 		uint64_t firstSeen { 0 };
@@ -310,6 +354,7 @@ private:
 	uint32_t m_time1Mhz { 0 };
 	uint64_t m_df11Clock { 0 };
 	std::array<DF11Candidate, 256> m_df11Candidates{};
+	std::array<RejectedFrameCandidate, RejectedCandidateCount> m_rejectedCandidates{};
 
     // the table with the icao addresses including transponder CA 
 	std::unique_ptr<Entry[]> m_table;

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -51,6 +51,47 @@ bool hashCollisionsCannotConfirmAnotherAddress() {
     return !table.confirmDF11Candidate(first);
 }
 
+bool rejectedFramesNeedIndependentConfirmation() {
+    ICAOTable table;
+    constexpr uint32_t icao = 0xabcdef;
+    constexpr uint64_t frame = 0x0200102acac271;
+
+    if (table.confirmRejectedShort(icao, frame))
+        return false;
+    if (table.confirmRejectedShort(icao, frame))
+        return false;
+
+    tick(table, ICAOTable::RejectedCandidateMinTicks);
+    if (!table.confirmRejectedShort(icao, frame))
+        return false;
+    return !table.confirmRejectedShort(icao, frame ^ 1);
+}
+
+bool expiredRejectedFramesNeedNewPair() {
+    ICAOTable table;
+    constexpr uint32_t icao = 0xabcdef;
+    constexpr uint64_t frame = 0x0200102acac271;
+
+    if (table.confirmRejectedShort(icao, frame))
+        return false;
+    tick(table, ICAOTable::RejectedCandidateMaxTicks + 1);
+    return !table.confirmRejectedShort(icao, frame);
+}
+
+bool shortAndLongCandidatesCannotConfirmEachOther() {
+    ICAOTable table;
+    constexpr uint32_t icao = 0xabcdef;
+    constexpr uint64_t frame = 0x0200102acac271;
+
+    if (table.confirmRejectedShort(icao, frame))
+        return false;
+    tick(table, ICAOTable::RejectedCandidateMinTicks);
+    if (table.confirmRejectedLong(icao, 0, frame))
+        return false;
+    tick(table, ICAOTable::RejectedCandidateMinTicks);
+    return table.confirmRejectedLong(icao, 0, frame);
+}
+
 bool emptySlotsRejectUnknownAddresses() {
     ICAOTable table;
     constexpr uint32_t unknownWithCA = 0x5abcde1;
@@ -117,6 +158,9 @@ int main() {
     return !(confirmsOnlySeparateSightings()
         && expiresOldSightings()
         && hashCollisionsCannotConfirmAnotherAddress()
+        && rejectedFramesNeedIndependentConfirmation()
+        && expiredRejectedFramesNeedNewPair()
+        && shortAndLongCandidatesCannotConfirmEachOther()
         && emptySlotsRejectUnknownAddresses()
         && insertedAndReplacementEntriesAreFound()
         && expiredEntriesDisappear()


### PR DESCRIPTION
## Summary

- retain the existing altitude and squawk plausibility checks for DF0/4/5/16/20/21
- hold a semantically rejected address-parity reply and emit it only after the identical complete frame from the same active ICAO is seen again
- require the two observations to be 100 microseconds to two seconds apart, excluding phase duplicates while keeping the evidence local
- keep corroborated Gillham and unsupported metric altitude replies from updating the stored altitude reference

## Motivation

For address-parity replies, a valid CRC syndrome identifies the sender only when that ICAO is already known. Stream1090 already enforces that condition, then applies an additional altitude or squawk plausibility check. That second check is useful against false candidates, but it also rejects valid raw replies when the field is unavailable (for example AC=0), cannot yet be validated, or uses an unsupported encoding.

This change preserves the semantic gate and adds a conservative fallback. The first rejected observation is still withheld. A bounded direct-mapped table accepts only a byte-for-byte identical 56- or 112-bit frame with the same recovered ICAO inside the confirmation window. Short and long frames cannot confirm each other. A table collision can only replace a candidate and lose a recovery; it cannot confirm a different frame. The table adds approximately 64 KiB per ICAO cache.

## Validation

- Release build succeeds on macOS/Apple Silicon
- all 7 CTest tests pass
- new unit coverage checks minimum separation, expiry, payload identity, and short/long isolation
- two replays of the final build over a 10-second IQ capture produced byte-identical output

On `rpi243-20260729-g20-6msps-u16real-60s.bin`, replayed at 6 -> 24 MHz with the built-in FIR:

| | Messages | User CPU |
|---|---:|---:|
| current `origin/main` | 31,854 | 37.17 s |
| this branch | 31,855 | 37.29 s |

The branch added one DF21, removed no baseline messages, and two branch runs were byte-identical. The CPU difference is within run-to-run noise (wall time was 38.15 s for main and 38.05 s for the branch).

An earlier experiment on the complete 71,824,310,272-byte Australian capture, using its custom 10 -> 24 MHz filter, measured:

| | Messages |
|---|---:|
| baseline before PR #31 | 718,707 |
| corroborated AP recovery | 734,953 |
| change | **+16,246 (+2.26%)** |

The additions were dominated by DF0 (+14,305) and DF4 (+1,693). Of the 16,246 additions, 14,146 were independently emitted by readsb, 13,770 by dump1090, and 14,397 by at least one of them. No baseline messages were removed. PR #31 recovered only four messages on this capture under its independent Gillham policy, so overlap should be negligible; the full capture has not yet been replayed on post-#31 main.
