### PR TITLE
Fix 10 to 24 MHz optimizer example

### DIFF
--- a/README_ADV.md
+++ b/README_ADV.md
@@ -170,7 +170,7 @@ python filter_opt.py --data samples.bin --fs 10000000 --fs-up 24000000 --num-gai
 ```
 So let us go through the parameters.
 - Tell the script to optimize on our sample data by `--data samples.bin`
-- The samples have been recorded at 10 Msps and we want to optimize for an internal upsampling rate of 24 Msps. `--fs 10000000 --fs-up 24000000` corresponds to running stream1090 with `-s 10 -u 10`. Note that these are given in Hz here. 
+- The samples have been recorded at 10 Msps and we want to optimize for an internal upsampling rate of 24 Msps. `--fs 10000000 --fs-up 24000000` corresponds to running stream1090 with `-s 10 -u 24`. Note that these are given in Hz here.
 - The number of gain points used by the optimizer is set via `--num-gain-points 9`. Please stick to 9 for now.
 - `--num-taps 15` determines the number of taps to be calculated from the gain points. 15 is stream1090 default. **Important:** This number has to be odd for now.
 - Since we do not provide any initial starting solution we set the bounds for the gain points to something very large by `--margin 1.0`


### PR DESCRIPTION
## Summary

Correct the filter optimizer example for a 10 MHz input and 24 MHz internal rate from:

```text
-s 10 -u 10
```

to:

```text
-s 10 -u 24
```

## Why

The optimizer command immediately above uses `--fs 10000000 --fs-up 24000000`, but the corresponding stream1090 command selected the 10 -> 10 MHz pipeline. That could make users test 24 MHz filter taps with a different pipeline from the one they were optimized for.

## Validation

- confirmed the 10 -> 24 MHz combination in `include/Presets.hpp` and `include/Sampler.hpp`
- confirmed the main README already documents `-s 10 -u 24`
- `git diff --check` passes

Documentation-only change; no runtime tests were required.
