### PR TITLE
Let a Gillham altitude establish the altitude it is checked against

### DIFF
--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -85,7 +85,7 @@ public:
 			const auto alt_bits = ModeS::extractSquawkAlt_Long(frame);
 			const auto alt = ModeS::decodeAltitude(alt_bits);
 			const bool altitudeAccepted = alt
-				&& m_cache.checkAltitude(it, *alt, alt_bits & 0x0010);
+				&& m_cache.checkAltitude(it, *alt);
 			if (!altitudeAccepted
 					&& !m_cache.confirmRejectedLong(crc, frame.high(), frame.low())) {
 				return false;
@@ -120,7 +120,7 @@ public:
 			const auto alt_bits = ModeS::extractSquawkAlt_Short(frameShort);
 			const auto alt = ModeS::decodeAltitude(alt_bits);
 			const bool altitudeAccepted = alt
-				&& m_cache.checkAltitude(it, *alt, alt_bits & 0x0010);
+				&& m_cache.checkAltitude(it, *alt);
 			if (!altitudeAccepted
 					&& !m_cache.confirmRejectedShort(crc, frameShort)) {
 				return false;


### PR DESCRIPTION
Follow-on to b8bae94 "Decode Gillham Q=0 altitude replies". The decode landed, but the state machine behind it still cannot use the result.

## The problem

`checkAltitude` takes an `updateState` flag, and both call sites pass the Q bit for it:

```cpp
m_cache.checkAltitude(it, *alt, alt_bits & 0x0010)
```

So a Gillham reply always arrives with `updateState == false`. It may be compared against a stored altitude, but it may never store one, and the first branch of that function returns false whenever nothing has been established yet:

```cpp
if (!updateState && state.altitude_cnt == 0)
    return false;
```

For a transponder that reports Gillham and nothing else, that condition never clears. `altitude_cnt` stays zero for the life of the cache entry, so every DF 0, 4, 16 and 20 it sends is rejected — permanently — and the decode added in b8bae94 never gets to matter for it.

Replaying the acceptance rules over 23792 frames that readsb decoded from a 30 minute Airspy capture and stream1090 did not: **49.5% are Q=0 Gillham, and 96.3% of those demodulate to exactly the right bits.** They are not being lost on the air.

## Why writing the state is safe

The comparison tolerance is 2000 ft, twenty times coarser than Gillham's 100 ft resolution, so nothing is lost by the coarser source. The stored value is exact either way: `altitude_25ft` holds `newAlt / 25`, and a Gillham altitude is always a multiple of 100.

## Measurements

Over the whole 30 minute capture, not a slice of it, at `-s 10 -u 24 -q`:

| DF | before | after | delta |
|---|---:|---:|---:|
| DF 0 | 109,518 | 110,767 | +1.14% |
| DF 4 | 18,192 | 19,970 | +9.77% |
| DF16 | 5,301 | 5,843 | +10.22% |
| DF20 | 57,390 | 57,920 | +0.92% |
| **total** | **717,550** | **721,642** | **+0.57%** |

Only the four formats that reach `checkAltitude` move. DF 5, 11, 17, 18 and 21 come out unchanged, which is both what the change should do and a useful check that it does nothing else.

It is not a strict superset: 4392 message occurrences appear and 300 disappear. Per format that nets out to −6 DF17 and −1 DF21, so the 300 are almost all the same message landing on a different phase or duplicate decision once the tracked altitude starts evolving. That is 0.04% of the output, and worth knowing before anyone diffs the two streams.

Corroborated against readsb on one slice, converted to SC16Q11 at 2.4 MS/s and run with `--preamble-threshold=40`: of the 47 messages this adds there, **41 are also decoded by readsb (87.2%)**, against **92.7%** for the output stream1090 already emits. The added messages corroborate about as well as the ones already trusted.

## Caveats

One capture, one site, one receiver.

Earlier revisions of this PR put the change behind an `ENABLE_GILLHAM_STATE` option so the A/B would be easy to run. That is gone: the flag existed to make the measurement convenient, not because the old behaviour is worth keeping, and `updateState` receiving the Q bit is a call-site mistake rather than a policy choice. The change is now two lines and applies directly.
