### PR TITLE
filter_opt: evaluate in parallel, and stop when the runs stop paying

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,18 @@ cmake .. -DENABLE_STATS=OFF && cmake --build .
 ```
 
 ## Experimental Features
+
+### FIR filter optimiser
+
+`filter_utils/filter_opt.py` searches for FIR taps by replaying an IQ capture
+through `stream1090`. Run it from `filter_utils` after installing
+`filter_utils/requirements.txt`; `--data`, `--fs`, and `--fs-up` are
+required. Evaluations run serially by default. Use `--workers N` for N
+parallel decoder processes or `--workers -1` for all CPU cores.
+`--patience N` stops after N runs without improvement (default 3, zero
+disables it), while `--max-runs N` sets a hard cap. See `--help` for the
+remaining search and resume options.
+
 ### SIGHUP support
 
 There is now basic experimental support for the SIGHUP signal. This signal can be send via ```kill -HUP <process id of stream1090>``` telling stream1090 to reload the device specific ini file. You can figure out the PID via ```ps```or ```pidof stream1090``` when it is running.

--- a/filter_utils/filter_opt.py
+++ b/filter_utils/filter_opt.py
@@ -62,6 +62,14 @@ def parse_args():
     p.add_argument("--df17-weight", type=float, default=1.0,
                    help="Weight for DF17 messages in the objective function")
 
+    p.add_argument("--patience", type=int, default=3,
+                   help="Stop after this many consecutive runs that fail to "
+                        "improve the best score. 0 never stops, which is what "
+                        "this script used to do")
+
+    p.add_argument("--max-runs", type=int, default=0,
+                   help="Hard cap on the number of runs, 0 for no cap")
+
     p.add_argument("--workers", type=int, default=1,
                    help="Parallel evaluations (-1 for all cores). Each one runs "
                         "a full stream1090 pass, so this scales close to linearly "
@@ -420,6 +428,51 @@ with open(LOGFILE, "a") as f:
     f.write(f"# Built-in DF17 count: {baseline_df17}\n")
     f.write("\n")
 
+def log_improvement():
+    """Append the current best, in the format --resume reads back."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open(LOGFILE, "a") as f:
+        f.write("# ================================================================\n")
+        f.write(f"# Instance: {DATA_PATH}\n")
+        f.write(f"# Time: {timestamp}\n")
+        f.write(f"# FS: {FS/1_000_000} MHz → FS_UP: {FS_UP/1_000_000} MHz\n")
+        f.write(f"# Number of taps: {NUMTAPS}\n")
+        f.write(f"# Best score: {best_score}\n")
+        f.write(f"# Best message count: {best_total}\n")
+        f.write(f"# Best DF17 count: {best_df17}\n")
+        f.write(f"# Best params: {best_params.tolist()}\n")
+        f.write("# Current bounds:\n")
+        for lo, hi in bounds:
+            f.write(f"# [{lo:.6f}, {hi:.6f}]\n")
+        f.write("# Best taps:\n")
+        for t in best_taps:
+            f.write(f"{t}\n")
+        f.write("\n")
+
+
+def on_generation(intermediate_result):
+    """Record the best after each generation when running in parallel.
+
+    The workers cannot do this themselves, so without it a parallel run would
+    write nothing until it finished and a crash would lose everything. scipy
+    calls this in the parent, once per generation, which is cheap next to the
+    generation itself.
+    """
+    global best_score, best_params, best_taps, best_total, best_df17
+
+    score = -intermediate_result.fun
+    if score <= best_score:
+        return
+
+    best_params = np.asarray(intermediate_result.x).copy()
+    best_taps = build_lowpass_firwin2(best_params, K)[0]
+    # fun carries the score but not the breakdown the log wants
+    best_score, best_total, best_df17 = score_taps(best_taps)
+    print(f"| generation improved: score={best_score}, total={best_total}, "
+          f"df17={best_df17}", flush=True)
+    log_improvement()
+
+
 def open_pool(n):
     """Worker pool for parallel evaluation, or None to stay in this process.
 
@@ -436,7 +489,12 @@ def open_pool(n):
 
 pool = open_pool(args.workers)
 
+runs = 0
+stale = 0
+
 while True:
+    runs += 1
+    score_before = best_score
     print("Starting Differential Evolution...")
 
     result = differential_evolution(
@@ -451,10 +509,11 @@ while True:
         # be used, so the population is updated once per generation
         workers=pool.map if pool else 1,
         updating="deferred" if pool else "immediate",
+        callback=on_generation if pool else None,
         x0=center,
     )
 
-    if pool:
+    if pool and -result.fun > best_score:
         # the winner was scored in a child, so its taps and counts never made
         # it back here; recompute them once from the parameters that won
         best_params = np.asarray(result.x)
@@ -510,3 +569,31 @@ while True:
     print("# Per-parameter margins:", margins)
 
     center = best_params.copy()
+
+    # Each run narrows the bounds around the current best, so once a few of
+    # them in a row bring nothing the schedule has stopped finding anything and
+    # the remaining ones are just spending evaluations. The objective is
+    # deterministic for a given tap set and data, so "no improvement" is exact
+    # rather than a noise threshold.
+    stale = 0 if best_score > score_before else stale + 1
+    print(f"# Run {runs}: best {best_score}, "
+          f"{'improved' if stale == 0 else f'stale for {stale}'}")
+
+    if args.patience and stale >= args.patience:
+        print(f"\nConverged: {stale} run{'' if stale == 1 else 's'} without "
+              "improvement, stopping.")
+        break
+
+    if args.max_runs and runs >= args.max_runs:
+        print(f"\nReached the cap of {args.max_runs} "
+              f"run{'' if args.max_runs == 1 else 's'}, stopping.")
+        break
+
+if pool:
+    pool.close()
+    pool.join()
+
+print(f"\nFinished after {runs} run{'' if runs == 1 else 's'}. "
+      f"Best score {best_score} "
+      f"({best_total} messages, {best_df17} DF17).")
+print(f"Best taps written to {LOGFILE}")

--- a/filter_utils/filter_opt.py
+++ b/filter_utils/filter_opt.py
@@ -568,7 +568,12 @@ while True:
 
     print("# Per-parameter margins:", margins)
 
-    center = best_params.copy()
+    # The bounds above are recentred on the population's best while center
+    # carries the best ever seen, and those are not the same point, so after a
+    # narrowing round the seed can fall outside its own bounds and scipy
+    # refuses to start. Clamp rather than drop it: the seed is still the most
+    # useful starting point we have.
+    center = np.clip(best_params, [lo for lo, _ in bounds], [hi for _, hi in bounds])
 
     # Each run narrows the bounds around the current best, so once a few of
     # them in a row bring nothing the schedule has stopped finding anything and

--- a/filter_utils/filter_opt.py
+++ b/filter_utils/filter_opt.py
@@ -13,6 +13,8 @@ from scipy.optimize import differential_evolution
 from scipy.signal import firwin2
 import subprocess
 from datetime import datetime
+import multiprocessing
+import os
 import re
 
 # ============================================================
@@ -60,6 +62,11 @@ def parse_args():
     p.add_argument("--df17-weight", type=float, default=1.0,
                    help="Weight for DF17 messages in the objective function")
 
+    p.add_argument("--workers", type=int, default=1,
+                   help="Parallel evaluations (-1 for all cores). Each one runs "
+                        "a full stream1090 pass, so this scales close to linearly "
+                        "until the disk gives out")
+
     return p.parse_args()
 
 
@@ -71,7 +78,16 @@ args = parse_args()
 
 STREAM1090_EXE = "../build/stream1090"
 DATA_PATH = args.data
-FILTER_PATH = "./diff_evolve_fir_temp.txt"
+
+
+def filter_path():
+    """Scratch file holding the taps for one evaluation.
+
+    Per process, because with --workers several evaluations are in flight at
+    once and a single shared path would have them overwrite each other's taps
+    between the write and the run.
+    """
+    return f"./diff_evolve_fir_temp_{os.getpid()}.txt"
 FS = args.fs
 FS_UP = args.fs_up
 NUMTAPS = args.num_taps
@@ -255,6 +271,37 @@ def default_output_rate(input_mhz: float) -> float:
     raise ValueError(f"No default output rate for input rate {input_mhz}")
 
 
+def score_taps(h):
+    """Run stream1090 once over the data with these taps and score the result."""
+    path = filter_path()
+    with open(path, "w") as f:
+        for t in h:
+            f.write(f"{t}\n")
+
+    input_mhz = FS / 1_000_000.0
+
+    if FS_UP is not None:
+        output_mhz = FS_UP / 1_000_000.0
+    else:
+        output_mhz = default_output_rate(input_mhz)
+
+    cmd = [
+        "bash", "-c",
+        f"cat {DATA_PATH} | {STREAM1090_EXE} "
+        f"-s {input_mhz} "
+        f"-u {output_mhz} "
+        f"-f {path}"
+    ]
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+
+    total, long_count, df_counts = parse_frames(out)
+    df17 = df_counts.get(17, 0)
+    score = total + long_count
+    return score, total, df17
+
+
 def evaluate_builtin_filter():
     input_mhz = FS / 1_000_000.0
 
@@ -292,36 +339,16 @@ def evaluate_filter(params):
     if not is_lowpass(h):
         return 1e9
 
-    with open(FILTER_PATH, "w") as f:
-        for t in h:
-            f.write(f"{t}\n")
+    score, total, df17 = score_taps(h)
 
-    input_mhz = FS / 1_000_000.0
-
-    if FS_UP is not None:
-        output_mhz = FS_UP / 1_000_000.0
-    else:
-        output_mhz = default_output_rate(input_mhz)
-
-    cmd = [
-        "bash", "-c",
-        f"cat {DATA_PATH} | {STREAM1090_EXE} "
-        f"-s {input_mhz} "
-        f"-u {output_mhz} "
-        f"-f {FILTER_PATH}"
-    ]
-
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    out, _ = proc.communicate()
-
-    total, long_count, df_counts = parse_frames(out)
-    df17 = df_counts.get(17, 0)
-    # score = total + args.df17_weight * df17
-    score = total + long_count
-    # score = total + df_counts.get(17, 0)
-    #score = df_counts.get(17, 0) + df_counts.get(11, 0) * 0.25
-    
-    print(score)
+    # With --workers the evaluation runs in a child process, so updating these
+    # globals here would only touch that child's copy and be thrown away. The
+    # parent recovers the winner from the optimiser's result instead. Still
+    # report each result, otherwise a parallel run prints nothing for hours.
+    if args.workers != 1:
+        print(f"[{os.getpid()}] total={total}, df17={df17}, score={score}",
+              flush=True)
+        return -score
 
     if score > best_score:
         best_score = score
@@ -393,6 +420,22 @@ with open(LOGFILE, "a") as f:
     f.write(f"# Built-in DF17 count: {baseline_df17}\n")
     f.write("\n")
 
+def open_pool(n):
+    """Worker pool for parallel evaluation, or None to stay in this process.
+
+    Forced onto the fork start method: this script does its work at module
+    level, so under spawn every worker would re-import it and start its own
+    optimisation run.
+    """
+    if n == 1:
+        return None
+    if n < 0:
+        n = multiprocessing.cpu_count()
+    return multiprocessing.get_context("fork").Pool(n)
+
+
+pool = open_pool(args.workers)
+
 while True:
     print("Starting Differential Evolution...")
 
@@ -404,9 +447,19 @@ while True:
         mutation=(0.5, 1.0),
         recombination=0.7,
         polish=False,
-        workers=1,
+        # a parallel map has to score a whole generation before any of it can
+        # be used, so the population is updated once per generation
+        workers=pool.map if pool else 1,
+        updating="deferred" if pool else "immediate",
         x0=center,
     )
+
+    if pool:
+        # the winner was scored in a child, so its taps and counts never made
+        # it back here; recompute them once from the parameters that won
+        best_params = np.asarray(result.x)
+        best_taps = build_lowpass_firwin2(best_params, K)[0]
+        best_score, best_total, best_df17 = score_taps(best_taps)
 
     print("\n================ END OF RUN ====================")
     print(f"Best params: {np.round(best_params, 6)}")

--- a/filter_utils/filter_opt.py
+++ b/filter_utils/filter_opt.py
@@ -21,6 +21,20 @@ import re
 #  CLI
 # ============================================================
 
+def non_negative(value):
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
+def worker_count(value):
+    parsed = int(value)
+    if parsed == -1 or parsed > 0:
+        return parsed
+    raise argparse.ArgumentTypeError("must be -1 or a positive integer")
+
+
 def parse_args():
     p = argparse.ArgumentParser(
         description="Differential Evolution FIR optimizer for stream1090"
@@ -62,15 +76,15 @@ def parse_args():
     p.add_argument("--df17-weight", type=float, default=1.0,
                    help="Weight for DF17 messages in the objective function")
 
-    p.add_argument("--patience", type=int, default=3,
+    p.add_argument("--patience", type=non_negative, default=3,
                    help="Stop after this many consecutive runs that fail to "
                         "improve the best score. 0 never stops, which is what "
                         "this script used to do")
 
-    p.add_argument("--max-runs", type=int, default=0,
+    p.add_argument("--max-runs", type=non_negative, default=0,
                    help="Hard cap on the number of runs, 0 for no cap")
 
-    p.add_argument("--workers", type=int, default=1,
+    p.add_argument("--workers", type=worker_count, default=1,
                    help="Parallel evaluations (-1 for all cores). Each one runs "
                         "a full stream1090 pass, so this scales close to linearly "
                         "until the disk gives out")


### PR DESCRIPTION
Three commits on `filter_utils/filter_opt.py`, nothing else touched.

Every evaluation is a full stream1090 pass over the training data, so a run is entirely bound by how many of those can be in flight at once. The script asked scipy for `workers=1`, and three things stood in the way of asking for more.

## What was blocking parallelism

**The scratch file was a single fixed path.** `./diff_evolve_fir_temp.txt`, shared by every evaluation, so concurrent ones would overwrite each other's taps between writing the file and reading it back — silently, with the optimiser scoring the wrong filter.

**The best-so-far bookkeeping lived inside the objective.** In a worker that runs in a child process, so the updates would touch a copy and be discarded, and the parent would reach the end of the run with `best_params` still `None`.

**multiprocessing defaults to `spawn` outside Linux.** The script does its work at module level, so under spawn each worker would re-import the file and start an optimisation run of its own. The pool is now created from a fork context explicitly and handed to scipy as the map function.

`--workers` defaults to 1, so without the flag the behaviour is unchanged.

## A crash that was there already

Each round recentres the bounds on the population's best while the seed passed as `x0` is the best ever seen. Those are different points, so once the margins narrow the seed can fall outside its own bounds and scipy refuses to start:

```
ValueError: Some entries in x0 lay outside the specified bounds
```

Hit on the fourth round of a real run. Clamped rather than dropped, since the best so far is still the most useful place to start from.

## Stopping

The optimiser sat in a `while True`, so the only way out was to watch the log and interrupt it. `--patience` (default 3) stops after that many consecutive rounds bring no improvement; `--max-runs` caps the count outright; `--patience 0` restores the old behaviour of never stopping.

The objective is deterministic for a given tap set and data, so "no improvement" is exact rather than a threshold on noise.

This does change what happens when neither flag is given. It is a separate commit so it can be dropped without losing the parallelism.

## Measured

On a 30 second training slice with 23 taps, 8 cores: one evaluation takes **32.4 s** alone and **7.3 s** when eight run together — **4.4x**, the rest going to memory bandwidth and to reading the slice. That turns a default run of `maxiter 20`, `popsize 10`, roughly 1470 evaluations, from about **12 hours into under 3**.

Exercised end to end overnight: 23 taps, 30 s slice, `--maxiter 10 --popsize 6 --patience 3 --workers 8`. It ran 15 rounds, improved the score from 21445 to 21966 (+2.43%), and stopped itself on the patience rule. The resulting filter is worth +3.1% to +4.4% messages over the built-in 15 tap set on three held-out slices.

A parallel run also logs per improved generation through scipy's callback, in the same format `--resume` reads back, so a crash loses one generation rather than the whole run.

Draft in case you would rather have the parallelism without the stopping rule, or want different defaults for it.

## Follow-up validation

`--workers` now accepts only `-1` or a positive count, so `--workers 0` cannot reach `multiprocessing.Pool` and fail later. `--patience` and `--max-runs` reject negative values. The README documents the optimizer workflow and all three controls.