### PR TITLE
Read 2 MHz uint8 IQ

### DIFF
--- a/include/Presets.hpp
+++ b/include/Presets.hpp
@@ -42,6 +42,14 @@ constexpr auto presets = std::make_tuple(
 #else 
 constexpr auto presets = std::make_tuple(
     // RTL-SDR (uint8) default presets
+    // 2 MHz is the rate the original dump1090 used, so recordings pinned to it
+    // can be read without resampling them first. 12 MHz out is the useful point
+    // of the curve: 2 -> 8 decodes 3.7% fewer messages, and going past 12 buys
+    // nothing, since a bit is only two samples long at this input rate.
+    Preset<IQ_UINT8_RTL_SDR, Sampler_2_0_to_12_0_Mhz, IQPipelineOptions::NONE>{},
+    Preset<IQ_UINT8_RTL_SDR, Sampler_2_0_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR>{},
+    Preset<IQ_UINT8_RTL_SDR, Sampler_2_0_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{},
+
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_4_to_8_0_Mhz, IQPipelineOptions::NONE>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_4_to_8_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_4_to_8_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{},

--- a/include/Sampler.hpp
+++ b/include/Sampler.hpp
@@ -49,6 +49,7 @@ typedef SamplerBase<Rate_24_0_Mhz, Rate_24_0_Mhz> Sampler_24_0_to_24_0_Mhz;
 // 2.0 Mhz upsamplers
 typedef SamplerBase<Rate_2_0_Mhz, Rate_4_0_Mhz> Sampler_2_0_to_4_0_Mhz;
 typedef SamplerBase<Rate_2_0_Mhz, Rate_8_0_Mhz> Sampler_2_0_to_8_0_Mhz;
+typedef SamplerBase<Rate_2_0_Mhz, Rate_12_0_Mhz> Sampler_2_0_to_12_0_Mhz;
 
 // 2.4 Mhz upsamplers 
 typedef SamplerBase<Rate_2_4_Mhz, Rate_4_0_Mhz> Sampler_2_4_to_4_0_Mhz;


### PR DESCRIPTION
## Summary

- add `Sampler_2_0_to_12_0_Mhz` and the three uc8 presets that go with it
- no existing path changes; this is purely additive

## Motivation

2 MHz is the rate the original dump1090 sampled at, so recordings and test files pinned to it are common. stream1090 currently cannot read them at all — it refuses with `Unsupported rate combination: 2 -> 12`, and the data has to be resampled first, which is both a nuisance and a change to the samples being measured.

The concrete reason I wanted this: it makes dump1090's own test corpus usable. With this preset, `testfiles/modes1.bin` from antirez/dump1090 decodes **387 messages**, which gives a public, reproducible capture to point at when discussing RTL-SDR behaviour. I used exactly this to produce the RTL-SDR numbers in #28, and had to carry a local patch to do it.

## Why only 12 MHz out

Rather than adding a full set of rates, this adds the one useful point of the curve. Measured on that file repeated 100x (17.8 s of signal) on a Cortex-A72:

| output rate | messages | CPU |
| --- | --- | --- |
| `-u 8` | 37893 | 4.13 s |
| **`-u 12`** | **39292** | **5.44 s** |
| `-u 20` | 39094 | 8.38 s |
| `-u 24` | 39494 | 10.00 s |

`2 -> 8` leaves 3.7% of messages on the table. Going past 12 buys nothing: 20 decodes slightly *fewer* than 12 while costing twice the CPU, and 24 recovers only 0.5% for 84% more.

That plateau is what you would expect — a bit is only two samples long at 2 MHz, so past a point the extra phase streams are resampling the same interpolated curve rather than finding new information. Worth noting none of these are close to CPU bound: `-u 12` runs at 0.3x real time on a single A72 core.

## Cost

The three presets grow the binary by about **7.9%**, 1056248 to 1140024 bytes in a plain Release build here. I know binary size from preset duplication is a concern, so if that trade is not worth making by default I am happy to put it behind a CMake option instead — just say which you prefer.

## Validation

- Release build, `ctest`: 7/7 passed
- `stream1090 -s 2 -u 12 < testfiles/modes1.bin` decodes 387 messages; frames look sane (DF17 and DF11 from consistent ICAOs)
- `-s 2` with no `-u` auto-selects 12 MHz and decodes the same 387
- current `main` refuses the same invocation with `Unsupported rate combination`
