### PR TITLE
Cut demodulator and DSP CPU by 24% on a Pi 4, 15% on a Pi 5

### DIFF
--- a/include/IQPipeline.hpp
+++ b/include/IQPipeline.hpp
@@ -9,58 +9,81 @@
 
 #include <tuple>
 #include <cmath>
+#include <cstdint>
 #include <utility>
+#include "RawInputFormat.hpp"
 
 
+/*
+ * Leaky integrator, in fixed point. The accumulator carries the running mean
+ * shifted up by m_shift, so the update is an add and the mean is a shift back
+ * down, which makes the smoothing factor exactly a negative power of two.
+ * setAlpha() therefore snaps to the nearest such factor: the default 0.005
+ * becomes 1/256.
+ */
 struct DCRemoval {
     explicit DCRemoval(float alpha = 0.005f)
-        : m_alpha(alpha), m_avg_I(0.0f), m_avg_Q(0.0f)
+        : m_shift(shiftForAlpha(alpha)), m_acc_I(0), m_acc_Q(0)
     {}
 
-    void apply(float& I, float& Q) noexcept {
-        float dI = I - m_avg_I;
-        float dQ = Q - m_avg_Q;
+    void apply(int16_t& I, int16_t& Q) noexcept {
+        const int32_t dI = int32_t(I) - (m_acc_I >> m_shift);
+        const int32_t dQ = int32_t(Q) - (m_acc_Q >> m_shift);
 
-        m_avg_I += dI * m_alpha;
-        m_avg_Q += dQ * m_alpha;
+        m_acc_I += dI;
+        m_acc_Q += dQ;
 
-        I = dI;
-        Q = dQ;
+        I = int16_t(dI);
+        Q = int16_t(dQ);
+    }
+
+    void applyBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
+        for (size_t i = 0; i < n; i++)
+            apply(I[i], Q[i]);
     }
 
     void setAlpha(float alpha) noexcept {
-        m_alpha = alpha;
+        m_shift = shiftForAlpha(alpha);
     }
 
-    std::string toString() const { 
-        std::ostringstream oss; 
-        oss << "[DCRemoval] alpha: " << m_alpha; 
-        return oss.str(); 
+    std::string toString() const {
+        std::ostringstream oss;
+        oss << "[DCRemoval] alpha: 1/" << (1 << m_shift);
+        return oss.str();
     }
 private:
-    float m_alpha;
-    float m_avg_I;
-    float m_avg_Q;
+    // nearest shift k with 2^-k closest to alpha in the log domain
+    static int shiftForAlpha(float alpha) noexcept {
+        if (!(alpha > 0.0f)) return 8;
+        int k = int(std::lround(std::log2(1.0f / alpha)));
+        if (k < 1)  k = 1;
+        if (k > 20) k = 20;
+        return k;
+    }
+
+    int m_shift;
+    int32_t m_acc_I;
+    int32_t m_acc_Q;
 };
 
 
 struct FlipSigns {
     FlipSigns() = default;
 
-    void apply(float& I, float& Q) noexcept {
+    void apply(int16_t& I, int16_t& Q) noexcept {
         if (m_flip) {
-            I = -I;
-            Q = -Q;
+            I = int16_t(-I);
+            Q = int16_t(-Q);
         }
         m_flip = !m_flip;
     }
 
     // Every second sample gets negated, so over a block that is a plain stride
     // two walk instead of a branch per sample.
-    void applyBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
+    void applyBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
         for (size_t i = m_flip ? 0 : 1; i < n; i += 2) {
-            I[i] = -I[i];
-            Q[i] = -Q[i];
+            I[i] = int16_t(-I[i]);
+            Q[i] = int16_t(-Q[i]);
         }
         m_flip ^= (n & 1) != 0;
     }
@@ -80,17 +103,17 @@ public:
         : m_stages(std::move(stages)...)
     {}
 
-    float process(float I, float Q) noexcept {
+    int32_t process(int16_t I, int16_t Q) noexcept {
         // run IQ through the stages
         applyStages(I, Q, std::index_sequence_for<Stages...>{});
-        // and compute the magnitude
-        return std::sqrt(I * I + Q * Q);
+        // and compute the squared magnitude
+        return int32_t(I) * int32_t(I) + int32_t(Q) * int32_t(Q);
     }
 
     // Runs the stages without taking the magnitude. The caller can then do the
     // magnitude for a whole block at once, which vectorizes, while the stages
     // themselves carry state from sample to sample and cannot.
-    void applyStages(float& I, float& Q) noexcept {
+    void applyStages(int16_t& I, int16_t& Q) noexcept {
         applyStages(I, Q, std::index_sequence_for<Stages...>{});
     }
 
@@ -99,7 +122,7 @@ public:
     // completion before starting the next gives the same numbers as running the
     // whole chain per sample. Stages that offer applyBlock() get to filter the
     // block their own way, which is where the FIR wins.
-    void applyStagesBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
+    void applyStagesBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
         applyStagesBlock(I, Q, n, std::index_sequence_for<Stages...>{});
     }
 
@@ -117,13 +140,13 @@ private:
 
     // runs the stages above on a single pair
     template<std::size_t... Is>
-    void applyStages(float& I, float& Q, std::index_sequence<Is...>) noexcept {
+    void applyStages(int16_t& I, int16_t& Q, std::index_sequence<Is...>) noexcept {
         // C++ fun: apply(I, Q) on each stage in order
         (std::get<Is>(m_stages).apply(I, Q), ...);
     }
 
     template<typename Stage>
-    static void runStageOnBlock(Stage& stage, float* I, float* Q, size_t n) noexcept {
+    static void runStageOnBlock(Stage& stage, int16_t* I, int16_t* Q, size_t n) noexcept {
         if constexpr (requires { stage.applyBlock(I, Q, n); }) {
             stage.applyBlock(I, Q, n);
         } else {
@@ -133,7 +156,7 @@ private:
     }
 
     template<std::size_t... Is>
-    void applyStagesBlock(float* I, float* Q, size_t n, std::index_sequence<Is...>) noexcept {
+    void applyStagesBlock(int16_t* I, int16_t* Q, size_t n, std::index_sequence<Is...>) noexcept {
         (runStageOnBlock(std::get<Is>(m_stages), I, Q, n), ...);
     }
 

--- a/include/IQPipeline.hpp
+++ b/include/IQPipeline.hpp
@@ -55,6 +55,16 @@ struct FlipSigns {
         m_flip = !m_flip;
     }
 
+    // Every second sample gets negated, so over a block that is a plain stride
+    // two walk instead of a branch per sample.
+    void applyBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
+        for (size_t i = m_flip ? 0 : 1; i < n; i += 2) {
+            I[i] = -I[i];
+            Q[i] = -Q[i];
+        }
+        m_flip ^= (n & 1) != 0;
+    }
+
     std::string toString() const { 
         return "[FlipSigns] enabled"; 
     }
@@ -77,6 +87,25 @@ public:
         return std::sqrt(I * I + Q * Q);
     }
 
+    // Runs the stages without taking the magnitude. The caller can then do the
+    // magnitude for a whole block at once, which vectorizes, while the stages
+    // themselves carry state from sample to sample and cannot.
+    void applyStages(float& I, float& Q) noexcept {
+        applyStages(I, Q, std::index_sequence_for<Stages...>{});
+    }
+
+    // Same, but stage by stage over a whole block. Every stage walks the block
+    // in order and only its own state carries over, so running one stage to
+    // completion before starting the next gives the same numbers as running the
+    // whole chain per sample. Stages that offer applyBlock() get to filter the
+    // block their own way, which is where the FIR wins.
+    void applyStagesBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
+        applyStagesBlock(I, Q, n, std::index_sequence_for<Stages...>{});
+    }
+
+    // true when there is nothing to run at all, so callers can skip a pass
+    static constexpr bool isEmpty = (sizeof...(Stages) == 0);
+
     std::string toString() const {
         return toStringImpl(std::index_sequence_for<Stages...>{});
     }
@@ -91,6 +120,21 @@ private:
     void applyStages(float& I, float& Q, std::index_sequence<Is...>) noexcept {
         // C++ fun: apply(I, Q) on each stage in order
         (std::get<Is>(m_stages).apply(I, Q), ...);
+    }
+
+    template<typename Stage>
+    static void runStageOnBlock(Stage& stage, float* I, float* Q, size_t n) noexcept {
+        if constexpr (requires { stage.applyBlock(I, Q, n); }) {
+            stage.applyBlock(I, Q, n);
+        } else {
+            for (size_t i = 0; i < n; i++)
+                stage.apply(I[i], Q[i]);
+        }
+    }
+
+    template<std::size_t... Is>
+    void applyStagesBlock(float* I, float* Q, size_t n, std::index_sequence<Is...>) noexcept {
+        (runStageOnBlock(std::get<Is>(m_stages), I, Q, n), ...);
     }
 
     template<std::size_t... Is>

--- a/include/InputBufferReader.hpp
+++ b/include/InputBufferReader.hpp
@@ -22,7 +22,7 @@ public:
           m_reader(ringBuffer)
     { }
 
-    inline void readMagnitude(float* out) {
+    inline void readMagnitude(int32_t* out) {
         m_reader.process([&](const RawType* buffer) {
             this->processBlock(buffer, out);
         });

--- a/include/InputReaderBase.hpp
+++ b/include/InputReaderBase.hpp
@@ -9,6 +9,9 @@
 
 #include <stdint.h>
 #include <string>
+#include <cmath>
+#include <algorithm>
+#include <type_traits>
 
 template<typename RawFormat, size_t InputBufferSize, typename Pipeline>
 class InputReaderBase {
@@ -18,16 +21,52 @@ public:
     InputReaderBase(Pipeline& pipeline) noexcept
         : m_pipeline(pipeline) {}
 
+    /*
+     * The samples make three short passes instead of one long one:
+     *
+     *   1. split the interleaved raw stream into an I and a Q array
+     *   2. run the pipeline stages, which carry state and stay scalar
+     *   3. turn I/Q into the magnitude
+     *
+     * Passes 1 and 3 have no loop carried dependency, so they vectorize. On
+     * ARM pass 1 becomes a deinterleaving load plus a widening convert, and
+     * pass 3 becomes a vector sqrt. In the fused per sample version neither
+     * could vectorize, because the stateful stage sat between them.
+     *
+     * The work is tiled so the two scratch arrays stay in L1 no matter how
+     * large the input buffer is.
+     */
     inline void processBlock(const RawType* __restrict in,
                              float* __restrict out) noexcept {
         constexpr size_t N = InputBufferSize;
-        for (size_t i = 0; i < N; ++i) {
-            float I = RawFormat::convertScalar(*in++);
-            float Q = RawFormat::convertScalar(*in++);
-            *out++ = m_pipeline.process(I, Q);
+
+        for (size_t base = 0; base < N; base += TileSize) {
+            const size_t n = std::min(TileSize, N - base);
+            const RawType* __restrict raw = in + 2 * base;
+
+            for (size_t i = 0; i < n; i++) {
+                m_tileI[i] = RawFormat::convertScalar(raw[2 * i]);
+                m_tileQ[i] = RawFormat::convertScalar(raw[2 * i + 1]);
+            }
+
+            if constexpr (!PipelineType::isEmpty) {
+                m_pipeline.applyStagesBlock(m_tileI, m_tileQ, n);
+            }
+
+            for (size_t i = 0; i < n; i++) {
+                out[base + i] = std::sqrt(m_tileI[i] * m_tileI[i] + m_tileQ[i] * m_tileQ[i]);
+            }
         }
     }
 
 private:
+    // callers hand in the pipeline as a reference type
+    using PipelineType = std::remove_reference_t<Pipeline>;
+
+    static constexpr size_t TileSize = (InputBufferSize < 512) ? InputBufferSize : 512;
+
+    alignas(32) float m_tileI[TileSize];
+    alignas(32) float m_tileQ[TileSize];
+
     Pipeline& m_pipeline;
 };

--- a/include/InputReaderBase.hpp
+++ b/include/InputReaderBase.hpp
@@ -30,14 +30,14 @@ public:
      *
      * Passes 1 and 3 have no loop carried dependency, so they vectorize. On
      * ARM pass 1 becomes a deinterleaving load plus a widening convert, and
-     * pass 3 becomes a vector sqrt. In the fused per sample version neither
+     * pass 3 becomes a vector square and add. In the fused per sample version neither
      * could vectorize, because the stateful stage sat between them.
      *
      * The work is tiled so the two scratch arrays stay in L1 no matter how
      * large the input buffer is.
      */
     inline void processBlock(const RawType* __restrict in,
-                             float* __restrict out) noexcept {
+                             int32_t* __restrict out) noexcept {
         constexpr size_t N = InputBufferSize;
 
         for (size_t base = 0; base < N; base += TileSize) {
@@ -45,8 +45,8 @@ public:
             const RawType* __restrict raw = in + 2 * base;
 
             for (size_t i = 0; i < n; i++) {
-                m_tileI[i] = RawFormat::convertScalar(raw[2 * i]);
-                m_tileQ[i] = RawFormat::convertScalar(raw[2 * i + 1]);
+                m_tileI[i] = RawFormat::convertFixed(raw[2 * i]);
+                m_tileQ[i] = RawFormat::convertFixed(raw[2 * i + 1]);
             }
 
             if constexpr (!PipelineType::isEmpty) {
@@ -54,7 +54,18 @@ public:
             }
 
             for (size_t i = 0; i < n; i++) {
-                out[base + i] = std::sqrt(m_tileI[i] * m_tileI[i] + m_tileQ[i] * m_tileQ[i]);
+                    // Linear magnitude, as before, but the samples are integers
+                    // now. Squaring the ring instead would be cheaper, and the
+                    // square root is monotone so it cannot flip a comparison --
+                    // but the resampler interpolates this ring, and interpolation
+                    // does not commute with squaring, which costs about 0.5% of
+                    // messages on a busy 2.4 Msps feed. Measured, so kept linear.
+                    const int32_t i2 = int32_t(m_tileI[i]) * int32_t(m_tileI[i]);
+                    const int32_t q2 = int32_t(m_tileQ[i]) * int32_t(m_tileQ[i]);
+                    // 8 fractional bits kept: the root of a weak sample is only
+                    // a couple of hundred, and truncating it to an integer costs
+                    // about 0.3% of messages on its own.
+                    out[base + i] = int32_t(std::sqrt(float(i2 + q2)) * 256.0f + 0.5f);
             }
         }
     }
@@ -65,8 +76,8 @@ private:
 
     static constexpr size_t TileSize = (InputBufferSize < 512) ? InputBufferSize : 512;
 
-    alignas(32) float m_tileI[TileSize];
-    alignas(32) float m_tileQ[TileSize];
+    alignas(32) int16_t m_tileI[TileSize];
+    alignas(32) int16_t m_tileQ[TileSize];
 
     Pipeline& m_pipeline;
 };

--- a/include/InputStreamReader.hpp
+++ b/include/InputStreamReader.hpp
@@ -22,7 +22,7 @@ public:
         std::fill(m_buffer.get(), m_buffer.get() + NumValuesToRead, RawType(0));
     }
 
-    inline void readMagnitude(float* out) {
+    inline void readMagnitude(int32_t* out) {
         constexpr size_t N = InputBufferSize;
         constexpr size_t NumValuesToRead = 2 * N;
         constexpr size_t NumBytesToRead  = NumValuesToRead * sizeof(RawType);

--- a/include/LowPassFilter.hpp
+++ b/include/LowPassFilter.hpp
@@ -9,17 +9,98 @@
 #include <numeric>
 #include <array>
 #include <cstddef>
+#include <algorithm>
 #include <bit>
 #include "Sampler.hpp"
 #include "CustomFilterTaps.hpp"
+
+/*
+ * How the filter is evaluated
+ * ---------------------------
+ * The output is
+ *
+ *     y[n] = sum_{k=0..N-1} taps[k] * x[n - (B-1) + k]      B = bit_ceil(N)
+ *
+ * so the taps run over B consecutive input samples ending at x[n]. Written per
+ * sample against a ring buffer, every tap needs its own masked index, the whole
+ * thing stays scalar, and the tap sum ends in a horizontal reduction.
+ *
+ * The block form flips the two loops. The samples of a block are copied behind
+ * the B-1 samples of history, which makes the input contiguous, and then the
+ * outer loop runs over the taps while the inner one produces four output
+ * samples at a time:
+ *
+ *     acc[0..3] += taps[k] * w[i+k .. i+k+3]
+ *
+ * Four independent accumulators, one tap shared across them, and no horizontal
+ * reduction at all. That inner group of four is what the vectorizer turns into
+ * a single vector FMA, so the shape is left to the compiler rather than
+ * written out in intrinsics.
+ *
+ * Summation stays in tap order, so each output accumulates its taps in the
+ * same sequence the plain scalar loop would use.
+ */
+namespace FirDetail {
+
+    // tap count rounded up to a whole group of four
+    constexpr size_t padTapCount(size_t n) noexcept {
+        return (n + 3u) & ~size_t(3u);
+    }
+
+    /// Filters one contiguous block. w* hold history followed by the new
+    /// samples, so w*[i + k] is the k-th tap partner of output i.
+    /// numTaps has to be a multiple of four, the padding taps being zero.
+    inline void firBlock(const float* __restrict taps, size_t numTaps,
+                         const float* __restrict wI, const float* __restrict wQ,
+                         float* __restrict outI, float* __restrict outQ,
+                         size_t n) noexcept {
+        size_t i = 0;
+
+        // Same shape in plain C++. The inner loop of four is what the
+        // vectorizer turns into a single vector FMA.
+        for (; i + 4 <= n; i += 4) {
+            float accI[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+            float accQ[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+            for (size_t k = 0; k < numTaps; k++) {
+                const float t = taps[k];
+                for (size_t l = 0; l < 4; l++) {
+                    accI[l] += t * wI[i + k + l];
+                    accQ[l] += t * wQ[i + k + l];
+                }
+            }
+
+            for (size_t l = 0; l < 4; l++) {
+                outI[i + l] = accI[l];
+                outQ[i + l] = accQ[l];
+            }
+        }
+
+        // whatever does not fill a vector
+        for (; i < n; i++) {
+            float sumI = 0.0f;
+            float sumQ = 0.0f;
+            for (size_t k = 0; k < numTaps; k++) {
+                sumI += taps[k] * wI[i + k];
+                sumQ += taps[k] * wQ[i + k];
+            }
+            outI[i] = sumI;
+            outQ[i] = sumQ;
+        }
+    }
+
+    // how many samples the block filter works on in one go
+    inline constexpr size_t ChunkSize = 256;
+
+} // namespace FirDetail
+
 
 template<SampleRate inputRate, SampleRate outputRate>
 class IQLowPass {
 public:
     IQLowPass() {
-        m_new_index = 0;
-        std::fill(std::begin(m_delay_I), std::end(m_delay_I), 0.0f);
-        std::fill(std::begin(m_delay_Q), std::end(m_delay_Q), 0.0f);
+        std::fill(std::begin(m_historyI), std::end(m_historyI), 0.0f);
+        std::fill(std::begin(m_historyQ), std::end(m_historyQ), 0.0f);
     }
 
     std::string toString() const {
@@ -36,103 +117,85 @@ public:
         return oss.str();
     }
 
-    void apply(float& value_I, float& value_Q) noexcept {
-        m_delay_I[m_new_index] = value_I;
-        m_delay_Q[m_new_index] = value_Q;
+    /// Filters a whole block in place. This is the path the input reader takes.
+    void applyBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
+        alignas(32) float workI[WorkSize];
+        alignas(32) float workQ[WorkSize];
 
-        float sum_I = 0.0f;
-        float sum_Q = 0.0f;
+        for (size_t base = 0; base < n; base += FirDetail::ChunkSize) {
+            const size_t m = std::min(FirDetail::ChunkSize, n - base);
 
-        // we check at compile time how we sum up
-        if constexpr(areTapsSymmetric) {
-            // regardless of the length, take the quick way
-            sum_sym(sum_I, sum_Q);        
-        } else {
-            // if they are not symmetric, we have to iterate over all taps
-            sum_not_sym(sum_I, sum_Q);
+            // history, then the fresh samples
+            std::copy(m_historyI, m_historyI + HistorySize, workI);
+            std::copy(m_historyQ, m_historyQ + HistorySize, workQ);
+            std::copy(I + base, I + base + m, workI + HistorySize);
+            std::copy(Q + base, Q + base + m, workQ + HistorySize);
+            // the zero taps of the last vector may reach past the samples, so
+            // make sure they land on zeros and not on stack garbage
+            std::fill(workI + HistorySize + m, workI + HistorySize + m + numPaddedTaps, 0.0f);
+            std::fill(workQ + HistorySize + m, workQ + HistorySize + m + numPaddedTaps, 0.0f);
+
+            FirDetail::firBlock(paddedTaps.data(), numPaddedTaps,
+                                workI, workQ, I + base, Q + base, m);
+
+            // the tail of the work buffer is the history of the next chunk
+            std::copy(workI + m, workI + m + HistorySize, m_historyI);
+            std::copy(workQ + m, workQ + m + HistorySize, m_historyQ);
         }
+    }
 
-        m_new_index = (m_new_index + 1) & (bufferSize - 1);
-        value_I = sum_I;
-        value_Q = sum_Q;
+    // single sample entry point, kept for pipelines that are driven per sample
+    void apply(float& value_I, float& value_Q) noexcept {
+        applyBlock(&value_I, &value_Q, 1);
     }
 
 private:
-    void sum_not_sym(float& sum_I, float& sum_Q) const noexcept{
-        // index that wraps around the ring buffer
-        int j = m_new_index;
-        for (size_t k = 0; k < numTaps; k++) {
-            j = (j + 1) & (bufferSize - 1);
-            sum_I += taps[k] * m_delay_I[j];
-            sum_Q += taps[k] * m_delay_Q[j];
-        }
-    }
-
-    void sum_sym(float& sum_I, float& sum_Q) const noexcept{
-        constexpr auto halfNumTaps = numTaps >> 1; 
-    
-        if constexpr(areTapsOdd) {
-            // compute the center index
-            const int center_index = (m_new_index + halfNumTaps + 1) & (bufferSize-1);
-            // deal with this separatly
-            sum_I += m_delay_I[center_index] * taps[halfNumTaps];
-            sum_Q += m_delay_Q[center_index] * taps[halfNumTaps];
-        }
-
-        // init i (left) and j (right)
-        int i = m_new_index;
-        int j = (m_new_index + numTaps + 1) & (bufferSize-1);
-
-        for (size_t k = 0; k < halfNumTaps; k++) {
-            i = (i + 1) & (bufferSize-1);
-            j = (j - 1) & (bufferSize-1);
-
-            sum_I += taps[k] * (m_delay_I[i] + m_delay_I[j]);
-            sum_Q += taps[k] * (m_delay_Q[i] + m_delay_Q[j]);
-        }
-    }  
-
     static constexpr auto taps = LowPassTaps::getCustomTaps<inputRate, outputRate>();
     static constexpr auto numTaps = taps.size();
     static constexpr auto bufferSize = std::bit_ceil(numTaps);
     static constexpr bool areTapsOdd = LowPassTaps::areCustomTapsOdd<inputRate, outputRate>();
-    static constexpr bool areTapsSymmetric = LowPassTaps::areCustomTapsSymmetric<inputRate, outputRate>(); 
-    
-    alignas(16) float m_delay_I[bufferSize];
-    alignas(16) float m_delay_Q[bufferSize];
-    int m_new_index;
+    static constexpr bool areTapsSymmetric = LowPassTaps::areCustomTapsSymmetric<inputRate, outputRate>();
+
+    static constexpr size_t numPaddedTaps = FirDetail::padTapCount(numTaps);
+
+    // the window of an output reaches B-1 samples back
+    static constexpr size_t HistorySize = bufferSize - 1;
+
+    // taps zero padded to a whole number of vectors
+    static constexpr auto paddedTaps = [] {
+        std::array<float, numPaddedTaps> p{};
+        for (size_t i = 0; i < numTaps; i++)
+            p[i] = taps[i];
+        return p;
+    }();
+
+    // room for the history, a chunk of samples, and the zero padded tap tail
+    static constexpr size_t WorkSize = FirDetail::ChunkSize + HistorySize + numPaddedTaps;
+
+    alignas(32) float m_historyI[HistorySize > 0 ? HistorySize : 1];
+    alignas(32) float m_historyQ[HistorySize > 0 ? HistorySize : 1];
 };
 
 
 template<size_t MaxNumTaps = 64>
 class IQLowPassDynamic {
 public:
-    IQLowPassDynamic() 
+    IQLowPassDynamic()
         :   m_numTaps(1),
             m_areTapsSymmetric(true),
-            m_areTapsOdd(true),
-            m_new_index(0) 
+            m_areTapsOdd(true)
     {
         // set all arrays to 0.0f
-        std::fill(std::begin(m_taps), std::end(m_taps), 0.0f);
-        std::fill(std::begin(m_delay_I), std::end(m_delay_I), 0.0f);
-        std::fill(std::begin(m_delay_Q), std::end(m_delay_Q), 0.0f);
+        std::fill(m_taps.begin(), m_taps.end(), 0.0f);
+        std::fill(m_historyI.begin(), m_historyI.end(), 0.0f);
+        std::fill(m_historyQ.begin(), m_historyQ.end(), 0.0f);
         // default is instant response pass through, i.e., 1 tap being 1.0f
-        m_taps[0] = 1.0f; 
+        m_taps[0] = 1.0f;
     }
 
-    IQLowPassDynamic(const std::vector<float>& taps) 
-        :   m_numTaps(1),
-            m_areTapsSymmetric(true),
-            m_areTapsOdd(true),
-            m_new_index(0) 
+    IQLowPassDynamic(const std::vector<float>& taps)
+        :   IQLowPassDynamic()
     {
-        // set all arrays to 0.0f
-        std::fill(std::begin(m_taps), std::end(m_taps), 0.0f);
-        std::fill(std::begin(m_delay_I), std::end(m_delay_I), 0.0f);
-        std::fill(std::begin(m_delay_Q), std::end(m_delay_Q), 0.0f);
-        // default is instant response pass through, i.e., 1 tap being 1.0f
-        m_taps[0] = 1.0f; 
         setTaps(taps);
     }
 
@@ -162,13 +225,17 @@ public:
     bool setTaps(const std::vector<float>& newTaps) {
         if (newTaps.size() == 0)
             return false;
-            
+
         if (newTaps.size() <= maxNumTaps()) {
-            // copy the new values
+            // copy the new values and clear whatever the previous taps left behind
+            std::fill(m_taps.begin(), m_taps.end(), 0.0f);
             std::copy(newTaps.begin(), newTaps.end(), m_taps.begin());
             // get the new number of tabs
             m_numTaps = newTaps.size();
             m_bufferSize = std::bit_ceil(m_numTaps);
+            m_historySize = m_bufferSize - 1;
+            // the block filter runs over whole vectors, the padding taps are zero
+            m_numPaddedTaps = FirDetail::padTapCount(m_numTaps);
             // check if we have an odd number of taps
             m_areTapsOdd = (m_numTaps % 2) != 0;
             // check if they are symmetric, regardless of if the number is odd or even
@@ -181,6 +248,9 @@ public:
                     break;
                 }
             }
+            // the old history was lined up for a different window length
+            std::fill(m_historyI.begin(), m_historyI.end(), 0.0f);
+            std::fill(m_historyQ.begin(), m_historyQ.end(), 0.0f);
             //printTabs();
             return true;
         }
@@ -230,7 +300,7 @@ public:
     }
 
 
-    // returns the maximum number of taps. 
+    // returns the maximum number of taps.
     // This is a compile time constant and is 64 by default.
     size_t maxNumTaps() const noexcept {
         return MaxNumTaps;
@@ -241,69 +311,47 @@ public:
         return m_numTaps;
     }
 
-    // applies the FIR to the I and Q values.
-    void apply(float& value_I, float& value_Q) noexcept {
-        m_delay_I[m_new_index] = value_I;
-        m_delay_Q[m_new_index] = value_Q;
+    /// Filters a whole block in place.
+    void applyBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
+        alignas(32) float workI[WorkSize];
+        alignas(32) float workQ[WorkSize];
 
-        float sum_I = 0.0f;
-        float sum_Q = 0.0f;
+        for (size_t base = 0; base < n; base += FirDetail::ChunkSize) {
+            const size_t m = std::min(FirDetail::ChunkSize, n - base);
 
-        // we check at run time how we sum up
-        if (m_areTapsSymmetric) {
-            // regardless of the length, take the quick way
-            sum_sym(sum_I, sum_Q);        
-        } else {
-            // if they are not symmetric, we have to iterate over all taps
-            sum_not_sym(sum_I, sum_Q);
+            std::copy(m_historyI.begin(), m_historyI.begin() + m_historySize, workI);
+            std::copy(m_historyQ.begin(), m_historyQ.begin() + m_historySize, workQ);
+            std::copy(I + base, I + base + m, workI + m_historySize);
+            std::copy(Q + base, Q + base + m, workQ + m_historySize);
+            // keep the zero taps of the last vector on zeros, not on stack garbage
+            std::fill(workI + m_historySize + m, workI + m_historySize + m + m_numPaddedTaps, 0.0f);
+            std::fill(workQ + m_historySize + m, workQ + m_historySize + m + m_numPaddedTaps, 0.0f);
+
+            FirDetail::firBlock(m_taps.data(), m_numPaddedTaps,
+                                workI, workQ, I + base, Q + base, m);
+
+            std::copy(workI + m, workI + m + m_historySize, m_historyI.begin());
+            std::copy(workQ + m, workQ + m + m_historySize, m_historyQ.begin());
         }
+    }
 
-        m_new_index = (m_new_index + 1) & (bufferSize() - 1);
-        value_I = sum_I;
-        value_Q = sum_Q;
+    // applies the FIR to a single I and Q pair.
+    void apply(float& value_I, float& value_Q) noexcept {
+        applyBlock(&value_I, &value_Q, 1);
     }
 
 private:
-    void sum_not_sym(float& sum_I, float& sum_Q) const noexcept {
-        // index that wraps around the ring buffer
-        int j = m_new_index;
-        for (size_t k = 0; k < numTaps(); k++) {
-            j = (j + 1) & (bufferSize() - 1);
-            sum_I += m_taps[k] * m_delay_I[j];
-            sum_Q += m_taps[k] * m_delay_Q[j];
-        }
-    }
+    static constexpr size_t TapCapacity     = FirDetail::padTapCount(MaxNumTaps);
+    static constexpr size_t MaxHistorySize  = std::bit_ceil(MaxNumTaps);
+    static constexpr size_t WorkSize        = FirDetail::ChunkSize + MaxHistorySize + TapCapacity;
 
-    void sum_sym(float& sum_I, float& sum_Q) const noexcept {
-        // half the number of taps
-        const auto halfNumTaps = numTaps() >> 1; 
-    
-        if (m_areTapsOdd) {
-            // compute the center index
-            const int center_index = (m_new_index + halfNumTaps + 1) & (bufferSize()-1);
-            // deal with this separatly
-            sum_I += m_delay_I[center_index] * m_taps[halfNumTaps];
-            sum_Q += m_delay_Q[center_index] * m_taps[halfNumTaps];
-        }
-
-        // init i (left) and j (right)
-        int i = m_new_index;
-        int j = (m_new_index + numTaps() + 1) & (bufferSize()-1);
-
-        for (size_t k = 0; k < halfNumTaps; k++) {
-            i = (i + 1) & (bufferSize()-1);
-            j = (j - 1) & (bufferSize()-1);
-
-            sum_I += m_taps[k] * (m_delay_I[i] + m_delay_I[j]);
-            sum_Q += m_taps[k] * (m_delay_Q[i] + m_delay_Q[j]);
-        }
-    }  
-
-    size_t bufferSize() const noexcept {
-        return m_bufferSize;
-    }
     // the number of taps currently used
     size_t m_numTaps;
+
+    // the same rounded up to a whole number of SIMD vectors
+    // firBlock() requires a multiple of four, and the default constructed
+    // filter is a one tap pass through, so start at a full group
+    size_t m_numPaddedTaps = FirDetail::padTapCount(1);
 
     // flag indicating if the taps are symmetric
     bool m_areTapsSymmetric;
@@ -311,17 +359,16 @@ private:
     // flag indicating if the number of taps is even or odd
     bool m_areTapsOdd;
 
-    // size of the delay buffers is the smallest power of 2 with >= maxNumTaps 
+    // size of the filter window is the smallest power of 2 with >= numTaps
     size_t m_bufferSize = 1;
 
-    // buffer for the taps
-    std::array<float, MaxNumTaps> m_taps;
+    // how far back an output reaches
+    size_t m_historySize = 0;
 
-    // and the delay buffers for I and Q values
-    std::array<float, std::bit_ceil(MaxNumTaps)> m_delay_I;
-    std::array<float, std::bit_ceil(MaxNumTaps)> m_delay_Q;
+    // buffer for the taps, zero padded to a whole vector
+    alignas(32) std::array<float, TapCapacity> m_taps;
 
-    // index where a new I and Q values are stored in the delay buffers
-    int m_new_index;
+    // the samples that the next block still needs
+    alignas(32) std::array<float, MaxHistorySize> m_historyI;
+    alignas(32) std::array<float, MaxHistorySize> m_historyQ;
 };
-

--- a/include/LowPassFilter.hpp
+++ b/include/LowPassFilter.hpp
@@ -9,6 +9,7 @@
 #include <numeric>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <algorithm>
 #include <bit>
 #include "Sampler.hpp"
@@ -47,45 +48,55 @@ namespace FirDetail {
         return (n + 3u) & ~size_t(3u);
     }
 
+    // taps live in Q15, samples in Q14, so a product is Q29 and a whole
+    // tap sum still fits an int32 as long as the taps sum to about one
+    inline constexpr int TapFracBits = 15;
+
+    constexpr int16_t toQ15(float t) noexcept {
+        const float x = t * float(1 << TapFracBits);
+        return int16_t(x >= 0.0f ? x + 0.5f : x - 0.5f);
+    }
+
     /// Filters one contiguous block. w* hold history followed by the new
     /// samples, so w*[i + k] is the k-th tap partner of output i.
     /// numTaps has to be a multiple of four, the padding taps being zero.
-    inline void firBlock(const float* __restrict taps, size_t numTaps,
-                         const float* __restrict wI, const float* __restrict wQ,
-                         float* __restrict outI, float* __restrict outQ,
+    inline void firBlock(const int16_t* __restrict taps, size_t numTaps,
+                         const int16_t* __restrict wI, const int16_t* __restrict wQ,
+                         int16_t* __restrict outI, int16_t* __restrict outQ,
                          size_t n) noexcept {
         size_t i = 0;
 
-        // Same shape in plain C++. The inner loop of four is what the
-        // vectorizer turns into a single vector FMA.
+        // The inner group of four is what the vectorizer turns into a widening
+        // multiply accumulate. Four int32 accumulators to a vector, the same
+        // count float had, but the operands are half the width.
         for (; i + 4 <= n; i += 4) {
-            float accI[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-            float accQ[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+            int32_t accI[4] = { 0, 0, 0, 0 };
+            int32_t accQ[4] = { 0, 0, 0, 0 };
 
             for (size_t k = 0; k < numTaps; k++) {
-                const float t = taps[k];
+                const int32_t t = taps[k];
                 for (size_t l = 0; l < 4; l++) {
-                    accI[l] += t * wI[i + k + l];
-                    accQ[l] += t * wQ[i + k + l];
+                    accI[l] += t * int32_t(wI[i + k + l]);
+                    accQ[l] += t * int32_t(wQ[i + k + l]);
                 }
             }
 
             for (size_t l = 0; l < 4; l++) {
-                outI[i + l] = accI[l];
-                outQ[i + l] = accQ[l];
+                outI[i + l] = int16_t((accI[l] + (1 << (TapFracBits - 1))) >> TapFracBits);
+                outQ[i + l] = int16_t((accQ[l] + (1 << (TapFracBits - 1))) >> TapFracBits);
             }
         }
 
         // whatever does not fill a vector
         for (; i < n; i++) {
-            float sumI = 0.0f;
-            float sumQ = 0.0f;
+            int32_t sumI = 0;
+            int32_t sumQ = 0;
             for (size_t k = 0; k < numTaps; k++) {
-                sumI += taps[k] * wI[i + k];
-                sumQ += taps[k] * wQ[i + k];
+                sumI += int32_t(taps[k]) * int32_t(wI[i + k]);
+                sumQ += int32_t(taps[k]) * int32_t(wQ[i + k]);
             }
-            outI[i] = sumI;
-            outQ[i] = sumQ;
+            outI[i] = int16_t((sumI + (1 << (TapFracBits - 1))) >> TapFracBits);
+            outQ[i] = int16_t((sumQ + (1 << (TapFracBits - 1))) >> TapFracBits);
         }
     }
 
@@ -99,8 +110,8 @@ template<SampleRate inputRate, SampleRate outputRate>
 class IQLowPass {
 public:
     IQLowPass() {
-        std::fill(std::begin(m_historyI), std::end(m_historyI), 0.0f);
-        std::fill(std::begin(m_historyQ), std::end(m_historyQ), 0.0f);
+        std::fill(std::begin(m_historyI), std::end(m_historyI), int16_t(0));
+        std::fill(std::begin(m_historyQ), std::end(m_historyQ), int16_t(0));
     }
 
     std::string toString() const {
@@ -118,9 +129,9 @@ public:
     }
 
     /// Filters a whole block in place. This is the path the input reader takes.
-    void applyBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
-        alignas(32) float workI[WorkSize];
-        alignas(32) float workQ[WorkSize];
+    void applyBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
+        alignas(32) int16_t workI[WorkSize];
+        alignas(32) int16_t workQ[WorkSize];
 
         for (size_t base = 0; base < n; base += FirDetail::ChunkSize) {
             const size_t m = std::min(FirDetail::ChunkSize, n - base);
@@ -132,8 +143,8 @@ public:
             std::copy(Q + base, Q + base + m, workQ + HistorySize);
             // the zero taps of the last vector may reach past the samples, so
             // make sure they land on zeros and not on stack garbage
-            std::fill(workI + HistorySize + m, workI + HistorySize + m + numPaddedTaps, 0.0f);
-            std::fill(workQ + HistorySize + m, workQ + HistorySize + m + numPaddedTaps, 0.0f);
+            std::fill(workI + HistorySize + m, workI + HistorySize + m + numPaddedTaps, int16_t(0));
+            std::fill(workQ + HistorySize + m, workQ + HistorySize + m + numPaddedTaps, int16_t(0));
 
             FirDetail::firBlock(paddedTaps.data(), numPaddedTaps,
                                 workI, workQ, I + base, Q + base, m);
@@ -145,7 +156,7 @@ public:
     }
 
     // single sample entry point, kept for pipelines that are driven per sample
-    void apply(float& value_I, float& value_Q) noexcept {
+    void apply(int16_t& value_I, int16_t& value_Q) noexcept {
         applyBlock(&value_I, &value_Q, 1);
     }
 
@@ -161,19 +172,19 @@ private:
     // the window of an output reaches B-1 samples back
     static constexpr size_t HistorySize = bufferSize - 1;
 
-    // taps zero padded to a whole number of vectors
+    // taps converted to Q15 and zero padded to a whole number of vectors
     static constexpr auto paddedTaps = [] {
-        std::array<float, numPaddedTaps> p{};
+        std::array<int16_t, numPaddedTaps> p{};
         for (size_t i = 0; i < numTaps; i++)
-            p[i] = taps[i];
+            p[i] = FirDetail::toQ15(taps[i]);
         return p;
     }();
 
     // room for the history, a chunk of samples, and the zero padded tap tail
     static constexpr size_t WorkSize = FirDetail::ChunkSize + HistorySize + numPaddedTaps;
 
-    alignas(32) float m_historyI[HistorySize > 0 ? HistorySize : 1];
-    alignas(32) float m_historyQ[HistorySize > 0 ? HistorySize : 1];
+    alignas(32) int16_t m_historyI[HistorySize > 0 ? HistorySize : 1];
+    alignas(32) int16_t m_historyQ[HistorySize > 0 ? HistorySize : 1];
 };
 
 
@@ -186,11 +197,11 @@ public:
             m_areTapsOdd(true)
     {
         // set all arrays to 0.0f
-        std::fill(m_taps.begin(), m_taps.end(), 0.0f);
-        std::fill(m_historyI.begin(), m_historyI.end(), 0.0f);
-        std::fill(m_historyQ.begin(), m_historyQ.end(), 0.0f);
+        std::fill(m_taps.begin(), m_taps.end(), int16_t(0));
+        std::fill(m_historyI.begin(), m_historyI.end(), int16_t(0));
+        std::fill(m_historyQ.begin(), m_historyQ.end(), int16_t(0));
         // default is instant response pass through, i.e., 1 tap being 1.0f
-        m_taps[0] = 1.0f;
+        m_taps[0] = FirDetail::toQ15(1.0f);
     }
 
     IQLowPassDynamic(const std::vector<float>& taps)
@@ -227,9 +238,10 @@ public:
             return false;
 
         if (newTaps.size() <= maxNumTaps()) {
-            // copy the new values and clear whatever the previous taps left behind
-            std::fill(m_taps.begin(), m_taps.end(), 0.0f);
-            std::copy(newTaps.begin(), newTaps.end(), m_taps.begin());
+            // copy the new values, in Q15, and clear whatever the previous taps left behind
+            std::fill(m_taps.begin(), m_taps.end(), int16_t(0));
+            for (size_t i = 0; i < newTaps.size(); i++)
+                m_taps[i] = FirDetail::toQ15(newTaps[i]);
             // get the new number of tabs
             m_numTaps = newTaps.size();
             m_bufferSize = std::bit_ceil(m_numTaps);
@@ -249,8 +261,8 @@ public:
                 }
             }
             // the old history was lined up for a different window length
-            std::fill(m_historyI.begin(), m_historyI.end(), 0.0f);
-            std::fill(m_historyQ.begin(), m_historyQ.end(), 0.0f);
+            std::fill(m_historyI.begin(), m_historyI.end(), int16_t(0));
+            std::fill(m_historyQ.begin(), m_historyQ.end(), int16_t(0));
             //printTabs();
             return true;
         }
@@ -312,9 +324,9 @@ public:
     }
 
     /// Filters a whole block in place.
-    void applyBlock(float* __restrict I, float* __restrict Q, size_t n) noexcept {
-        alignas(32) float workI[WorkSize];
-        alignas(32) float workQ[WorkSize];
+    void applyBlock(int16_t* __restrict I, int16_t* __restrict Q, size_t n) noexcept {
+        alignas(32) int16_t workI[WorkSize];
+        alignas(32) int16_t workQ[WorkSize];
 
         for (size_t base = 0; base < n; base += FirDetail::ChunkSize) {
             const size_t m = std::min(FirDetail::ChunkSize, n - base);
@@ -324,8 +336,8 @@ public:
             std::copy(I + base, I + base + m, workI + m_historySize);
             std::copy(Q + base, Q + base + m, workQ + m_historySize);
             // keep the zero taps of the last vector on zeros, not on stack garbage
-            std::fill(workI + m_historySize + m, workI + m_historySize + m + m_numPaddedTaps, 0.0f);
-            std::fill(workQ + m_historySize + m, workQ + m_historySize + m + m_numPaddedTaps, 0.0f);
+            std::fill(workI + m_historySize + m, workI + m_historySize + m + m_numPaddedTaps, int16_t(0));
+            std::fill(workQ + m_historySize + m, workQ + m_historySize + m + m_numPaddedTaps, int16_t(0));
 
             FirDetail::firBlock(m_taps.data(), m_numPaddedTaps,
                                 workI, workQ, I + base, Q + base, m);
@@ -336,7 +348,7 @@ public:
     }
 
     // applies the FIR to a single I and Q pair.
-    void apply(float& value_I, float& value_Q) noexcept {
+    void apply(int16_t& value_I, int16_t& value_Q) noexcept {
         applyBlock(&value_I, &value_Q, 1);
     }
 
@@ -366,9 +378,9 @@ private:
     size_t m_historySize = 0;
 
     // buffer for the taps, zero padded to a whole vector
-    alignas(32) std::array<float, TapCapacity> m_taps;
+    alignas(32) std::array<int16_t, TapCapacity> m_taps;
 
     // the samples that the next block still needs
-    alignas(32) std::array<float, MaxHistorySize> m_historyI;
-    alignas(32) std::array<float, MaxHistorySize> m_historyQ;
+    alignas(32) std::array<int16_t, MaxHistorySize> m_historyI;
+    alignas(32) std::array<int16_t, MaxHistorySize> m_historyQ;
 };

--- a/include/RawInputFormat.hpp
+++ b/include/RawInputFormat.hpp
@@ -7,6 +7,18 @@
 
 #pragma once
 
+#include <cstdint>
+
+/*
+ * The DSP chain runs in fixed point. Samples are int16 in Q14, so 16384 is
+ * full scale and there is a bit of headroom left in the type for a stage that
+ * overshoots. The conversions below are exact integer arithmetic; the half LSB
+ * of centring that the float versions carried is dropped, and the DC removal
+ * takes it out anyway.
+ */
+inline constexpr int SampleFracBits = 14;
+inline constexpr int SampleOne      = 1 << SampleFracBits;
+
 enum class InputFormatType {
     IQ_UINT8_RTL_SDR,
     IQ_UINT16_RAW_AIRSPY,
@@ -21,6 +33,15 @@ struct IQ_UINT8_RTL_SDR {
         constexpr float scale = 1.0f / 127.5f;
         return (float(v) - 127.5f) * scale;
     }
+
+    // 8 bit unsigned centred on 127.5, scaled to Q14. The centre is half an
+    // LSB below an integer, so the sample is doubled first and 255 subtracted:
+    // that keeps the arithmetic exact and matches convertScalar above. Centring
+    // on 128 instead costs about 2.7% of messages on a real dongle, because
+    // half an LSB is a large fraction of an eight bit sample.
+    static inline int16_t convertFixed(uint8_t v) noexcept {
+        return int16_t((int32_t(v) * 2 - 255) * (SampleOne / 256));
+    }
 };
 
 struct IQ_UINT16_RAW_AIRSPY {
@@ -31,6 +52,14 @@ struct IQ_UINT16_RAW_AIRSPY {
         constexpr float scale = (1.0f / 2047.5f);
         return (float(v) - 2047.5f) * scale;
     }
+
+    // 12 bit unsigned centred on 2047.5, scaled to Q14, same trick as above.
+    // Here it makes no measurable difference, because this format's -q pipeline
+    // runs DCRemoval and that absorbs the half LSB either way; it is done for
+    // consistency with convertScalar rather than for yield.
+    static inline int16_t convertFixed(uint16_t v) noexcept {
+        return int16_t((int32_t(v) * 2 - 4095) * (SampleOne / 4096));
+    }
 };
 
 struct IQ_FLOAT32 {
@@ -39,5 +68,10 @@ struct IQ_FLOAT32 {
 
     static inline float convertScalar(float v) noexcept {
         return v;
+    }
+
+    static inline int16_t convertFixed(float v) noexcept {
+        const float x = v * float(SampleOne);
+        return int16_t(x < -32768.0f ? -32768.0f : (x > 32767.0f ? 32767.0f : x));
     }
 };

--- a/include/SampleStream.hpp
+++ b/include/SampleStream.hpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <cmath>
 
+#include "RawInputFormat.hpp"
 #include "DemodCore.hpp"
 #include "Sampler.hpp"
 #include "MessageHandler.hpp"
@@ -121,7 +122,7 @@ public:
     static constexpr size_t NumSampleBuffers = 2;
     static constexpr size_t TotalSampleBufferLength = NumSampleBuffers * Sampler::SampleBufferSize + Sampler::SampleBufferOverlap;
 
-    SampleStream() : m_inputRingBuffer(0.0f), m_sampleRingBuffer(0.0f) { }
+    SampleStream() : m_inputRingBuffer(0), m_sampleRingBuffer(0) { }
    
     // the main method that streams from InputStream using inputReader
     template<typename InputReaderType, MessageHandler Handler>
@@ -137,10 +138,11 @@ public:
         // ShiftRegisters::extractAlignedFrameLong for the 16 bit alignment
         const size_t delay = (size_t(16) + frameBit) * Sampler::NumStreams;
         const auto offsetInBlock = size_t(m_demodPos - m_sampleRingBuffer.readPos());
-        const float first  = m_sampleRingBuffer.lookBack(delay - stream, offsetInBlock);
-        const float second = m_sampleRingBuffer.lookBack(delay - stream - (Sampler::NumStreams >> 1),
-                                                        offsetInBlock);
-        return std::fabs(first - second);
+        // the ring holds linear magnitudes scaled by MagScale
+        const float first  = float(m_sampleRingBuffer.lookBack(delay - stream, offsetInBlock));
+        const float second = float(m_sampleRingBuffer.lookBack(delay - stream - (Sampler::NumStreams >> 1),
+                                                               offsetInBlock));
+        return std::fabs(first - second) * (1.0f / MagScale);
     }
 
     uint8_t getRSSI() const noexcept {
@@ -152,12 +154,13 @@ public:
         const auto offsetInBlock = m_demodPos - m_sampleRingBuffer.readPos();
         // check the rssi of the surounding samples. This index is the first to
         // catch the message, usually with bad RSSI
-        float rssi = 0.0f;
+        int32_t peak = 0;
         for (size_t s = 0; s < Sampler::NumStreams; s++) {
-            float v = std::max(m_sampleRingBuffer.lookBack(samplesDelay + s, offsetInBlock), 
-                               m_sampleRingBuffer.lookBack(samplesDelay + s - (Sampler::NumStreams >> 1), offsetInBlock));
-            rssi = std::max(rssi, v);
-        }
+                int32_t v = std::max(m_sampleRingBuffer.lookBack(samplesDelay + s, offsetInBlock),
+                                     m_sampleRingBuffer.lookBack(samplesDelay + s - (Sampler::NumStreams >> 1), offsetInBlock));
+                peak = std::max(peak, v);
+            }
+            float rssi = float(peak) * (1.0f / MagScale);
         // normalize
         rssi = std::min(1.41f, rssi) / 1.41f;
         // and return as byte
@@ -165,13 +168,18 @@ public:
     }
 
 private:
-    uint32_t m_newBits[Sampler::NumStreams];    
+    // Samples reach the ring as ((I*I) >> 2) + ((Q*Q) >> 2) with I and Q in
+    // Q14, so the stored value is the squared magnitude times (SampleOne/2)^2
+    // and a linear magnitude comes back as stored / MagScale.
+    static constexpr float MagScale = float(SampleOne) * 256.0f;
+
+    uint32_t m_newBits[Sampler::NumStreams];
     // we have one ring buffer for the IQ pipeline
-    BlockRing<float, Sampler::InputBufferSize,  NumInputBuffers,  Sampler::InputBufferOverlap>  m_inputRingBuffer;
+    BlockRing<int32_t, Sampler::InputBufferSize,  NumInputBuffers,  Sampler::InputBufferOverlap>  m_inputRingBuffer;
     // and one for the upsampled magnitudes
-    BlockRing<float, Sampler::SampleBufferSize, NumSampleBuffers, Sampler::SampleBufferOverlap> m_sampleRingBuffer;
+    BlockRing<int32_t, Sampler::SampleBufferSize, NumSampleBuffers, Sampler::SampleBufferOverlap> m_sampleRingBuffer;
     // not nice. Will change
-    const float* m_demodPos = nullptr;
+    const int32_t* m_demodPos = nullptr;
 };
 
 

--- a/include/Sampler.hpp
+++ b/include/Sampler.hpp
@@ -8,6 +8,7 @@
 #pragma once
 #include <numeric>
 #include <cstddef>
+#include <cstdint>
 #include "SamplerFunc.hpp"
 
 enum SampleRate {
@@ -147,25 +148,35 @@ class SamplerBase {
     static constexpr bool isPassthrough = (InputSampleRate == OutputSampleRate);
 
     // the main sampling function that has to be implemented
-    static void sample(const float* __restrict in, float* __restrict out) noexcept {
+    static void sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
         SamplerFunc<RatioInput, RatioOutput, NumBlocks>::sample(in, out);
     };    
 };
 
 
+
+namespace SamplerMix {
+    // Weighted average of two neighbouring magnitudes. A magnitude already
+    // uses most of an int32, so the numerator is widened before the divide.
+    // Ratios whose denominator is a power of two collapse to a shift here.
+    inline int32_t mix(int32_t w0, int32_t a, int32_t w1, int32_t b, int32_t den) noexcept {
+        return int32_t((int64_t(w0) * int64_t(a) + int64_t(w1) * int64_t(b)) / den);
+    }
+}
+
 // 2.4 Mhz to 4.0 Mhz (4 streams) upsampling function
 template<>
-inline void SamplerBase<Rate_2_4_Mhz, Rate_4_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_2_4_Mhz, Rate_4_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     for (size_t i = 0; i < NumBlocks; i++) {
         //  |00000|11111|22222|33333|
         //  +-----------------------+
         //  |..000|00022|22224|44444|
         //  |.....|11111|13333|33...|
-        out[0] = (3.0f * in[0] + 3.0f * in[1]) * (1.0f / 6.0f);   
-        out[1] = (5.0f * in[1] + 1.0f * in[2]) * (1.0f / 6.0f);
-        out[2] = (2.0f * in[1] + 4.0f * in[2]) * (1.0f / 6.0f);
-        out[3] = (4.0f * in[2] + 2.0f * in[3]) * (1.0f / 6.0f);
-        out[4] = (1.0f * in[2] + 5.0f * in[3]) * (1.0f / 6.0f);
+        out[0] = SamplerMix::mix(3, in[0], 3, in[1], 6);   
+        out[1] = SamplerMix::mix(5, in[1], 1, in[2], 6);
+        out[2] = SamplerMix::mix(2, in[1], 4, in[2], 6);
+        out[3] = SamplerMix::mix(4, in[2], 2, in[3], 6);
+        out[4] = SamplerMix::mix(1, in[2], 5, in[3], 6);
         in += 3;
         out += 5;
     }   
@@ -173,18 +184,18 @@ inline void SamplerBase<Rate_2_4_Mhz, Rate_4_0_Mhz>::sample(const float* __restr
 
 // 2.4 Mhz to 6.0 Mhz (6 streams) upsampling function
 template<>
-inline void SamplerBase<Rate_2_4_Mhz, Rate_6_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_2_4_Mhz, Rate_6_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     for (size_t i = 0; i < NumBlocks; i++) {
         //  |00000|11111|22222|
         //  +-----------------+
         //  |00000|03333|33...|
         //  |..111|11144|4444.|
         //  |....2|22222|.....|
-        out[0] = (5.0f * in[0] + 1.0f * in[1]) * (1.0f / 6.0f);   
-        out[1] = (3.0f * in[0] + 3.0f * in[1]) * (1.0f / 6.0f);
-        out[2] = (1.0f * in[0] + 5.0f * in[1]) * (1.0f / 6.0f);
-        out[3] = (4.0f * in[1] + 2.0f * in[2]) * (1.0f / 6.0f);
-        out[4] = (2.0f * in[1] + 4.0f * in[2]) * (1.0f / 6.0f);
+        out[0] = SamplerMix::mix(5, in[0], 1, in[1], 6);   
+        out[1] = SamplerMix::mix(3, in[0], 3, in[1], 6);
+        out[2] = SamplerMix::mix(1, in[0], 5, in[1], 6);
+        out[3] = SamplerMix::mix(4, in[1], 2, in[2], 6);
+        out[4] = SamplerMix::mix(2, in[1], 4, in[2], 6);
         in += 2;
         out += 5;
     }
@@ -192,7 +203,7 @@ inline void SamplerBase<Rate_2_4_Mhz, Rate_6_0_Mhz>::sample(const float* __restr
 
 // 2.4 Mhz to 8.0 Mhz (8 streams) upsampling function
 template<>
-inline void SamplerBase<Rate_2_4_Mhz, Rate_8_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_2_4_Mhz, Rate_8_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     for (size_t i = 0; i < NumBlocks; i++) {
         //  |0000000000|1111111111|2222222222|3333333333|
         //  +-------------------------------------------+
@@ -200,16 +211,16 @@ inline void SamplerBase<Rate_2_4_Mhz, Rate_8_0_Mhz>::sample(const float* __restr
         //  |......1111|1111....55|555555....|99999999..|
         //  |.........2|2222222...|.66666666.|..........|
         //  |..........|..33333333|....777777|77........|
-        out[0] = ( 7.0f * in[0] +  1.0f * in[1]) * (1.0f / 8.0f);   
-        out[1] = ( 4.0f * in[0] +  4.0f * in[1]) * (1.0f / 8.0f);
-        out[2] = ( 1.0f * in[0] +  7.0f * in[1]) * (1.0f / 8.0f);
-        out[3] = ( 8.0f * in[1] +  0.0f * in[2]) * (1.0f / 8.0f);
-        out[4] = ( 5.0f * in[1] +  3.0f * in[2]) * (1.0f / 8.0f);
-        out[5] = ( 2.0f * in[1] +  6.0f * in[2]) * (1.0f / 8.0f);
-        out[6] = ( 8.0f * in[2] +  0.0f * in[3]) * (1.0f / 8.0f);
-        out[7] = ( 6.0f * in[2] +  2.0f * in[3]) * (1.0f / 8.0f);
-        out[8] = ( 3.0f * in[2] +  5.0f * in[3]) * (1.0f / 8.0f);
-        out[9] = ( 0.0f * in[2] +  8.0f * in[3]) * (1.0f / 8.0f);
+        out[0] = SamplerMix::mix(7, in[0], 1, in[1], 8);   
+        out[1] = SamplerMix::mix(4, in[0], 4, in[1], 8);
+        out[2] = SamplerMix::mix(1, in[0], 7, in[1], 8);
+        out[3] = SamplerMix::mix(8, in[1], 0, in[2], 8);
+        out[4] = SamplerMix::mix(5, in[1], 3, in[2], 8);
+        out[5] = SamplerMix::mix(2, in[1], 6, in[2], 8);
+        out[6] = SamplerMix::mix(8, in[2], 0, in[3], 8);
+        out[7] = SamplerMix::mix(6, in[2], 2, in[3], 8);
+        out[8] = SamplerMix::mix(3, in[2], 5, in[3], 8);
+        out[9] = SamplerMix::mix(0, in[2], 8, in[3], 8);
         in += 3;
         out += 10;
     } 
@@ -217,14 +228,14 @@ inline void SamplerBase<Rate_2_4_Mhz, Rate_8_0_Mhz>::sample(const float* __restr
 
 // 2.56 Mhz to 8.0 Mhz (8 streams) upsampling function
 template<>
-inline void SamplerBase<Rate_2_56_Mhz, Rate_8_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_2_56_Mhz, Rate_8_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     for (size_t i = 0; i < NumBlocks; i++) {
             for (int j = 0; j < 25; j++) {
                 const auto offset = 8 * j;
                 const auto k = offset / 25;
                 const auto l = 25 - (offset % 25);
                 const auto r = 25 - l;
-                out[j] = ((float)l * in[k] + (float)r * in[k+1]) * (1.0f / 25.0f);
+                out[j] = SamplerMix::mix((int32_t)l, in[k], (int32_t)r, in[k+1], 25);
             }
             in += 8;
             out += 25;
@@ -233,7 +244,7 @@ inline void SamplerBase<Rate_2_56_Mhz, Rate_8_0_Mhz>::sample(const float* __rest
 
 // 6.0 Mhz to 16.0 Mhz (16 streams) upsampling function
 template<>
-inline void SamplerBase<Rate_6_0_Mhz, Rate_16_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_6_0_Mhz, Rate_16_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
    for (size_t i = 0; i < NumBlocks; i++) {
             //  |00000000|11111111|22222222|33333333|
             //  +-----------------------------------+
@@ -246,14 +257,14 @@ inline void SamplerBase<Rate_6_0_Mhz, Rate_16_0_Mhz>::sample(const float* __rest
             //  |........|........|..666666|66......|
             //  |........|........|.....777|77777...|
             //  |........|........|........|88888888|
-            out[0] = ( 8.0f * in[0] +  0.0f * in[1]) * (1.0f / 8.0f);   
-            out[1] = ( 5.0f * in[0] +  3.0f * in[1]) * (1.0f / 8.0f);
-            out[2] = ( 2.0f * in[0] +  6.0f * in[1]) * (1.0f / 8.0f);
-            out[3] = ( 7.0f * in[1] +  1.0f * in[2]) * (1.0f / 8.0f);
-            out[4] = ( 4.0f * in[1] +  4.0f * in[2]) * (1.0f / 8.0f);
-            out[5] = ( 1.0f * in[1] +  7.0f * in[2]) * (1.0f / 8.0f);
-            out[6] = ( 6.0f * in[2] +  2.0f * in[3]) * (1.0f / 8.0f);
-            out[7] = ( 3.0f * in[2] +  5.0f * in[3]) * (1.0f / 8.0f);
+            out[0] = SamplerMix::mix(8, in[0], 0, in[1], 8);   
+            out[1] = SamplerMix::mix(5, in[0], 3, in[1], 8);
+            out[2] = SamplerMix::mix(2, in[0], 6, in[1], 8);
+            out[3] = SamplerMix::mix(7, in[1], 1, in[2], 8);
+            out[4] = SamplerMix::mix(4, in[1], 4, in[2], 8);
+            out[5] = SamplerMix::mix(1, in[1], 7, in[2], 8);
+            out[6] = SamplerMix::mix(6, in[2], 2, in[3], 8);
+            out[7] = SamplerMix::mix(3, in[2], 5, in[3], 8);
             in += 3;
             out += 8;
         }
@@ -261,7 +272,7 @@ inline void SamplerBase<Rate_6_0_Mhz, Rate_16_0_Mhz>::sample(const float* __rest
 
 // 6.0 Mhz to 12.0 Mhz (12 streams) upsampling function
 /*template<>
-inline void SamplerBase<Rate_6_0_Mhz, Rate_12_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_6_0_Mhz, Rate_12_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     for (size_t i = 0; i < NumBlocks; i++) {
         out[0] = 0.6f * in[0] +  0.4f * in[1];
         out[1] = 0.1f * in[0] +  0.9f * in[1];
@@ -272,7 +283,7 @@ inline void SamplerBase<Rate_6_0_Mhz, Rate_12_0_Mhz>::sample(const float* __rest
 
 // 6.0 Mhz to 12.0 Mhz (12 streams) upsampling function
 /*template<>
-inline void SamplerBase<Rate_6_0_Mhz, Rate_12_0_Mhz, 2>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_6_0_Mhz, Rate_12_0_Mhz, 2>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     for (size_t i = 0; i < NumBlocks; i++) {
         out[0] = -0.1f *  in[0] + 1.0f * in[1] - 0.1f * in[2];   
         out[1] =  0.5f *  in[0] + 0.5f * in[1] + 0.0f * in[2];   
@@ -283,12 +294,16 @@ inline void SamplerBase<Rate_6_0_Mhz, Rate_12_0_Mhz, 2>::sample(const float* __r
 
 // 6.0 Mhz to 24.0 Mhz (24 streams) upsampling function
 template<>
-inline void SamplerBase<Rate_6_0_Mhz, Rate_24_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_6_0_Mhz, Rate_24_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
+   // the weights are quarters, so these are exact integer shifts and the
+   // interpolation loses nothing at all
    for (size_t i = 0; i < NumBlocks; i++) {
-        out[0] = 1.0f  * in[0]  +  0.0f  * in[1];
-        out[1] = 0.75f * in[0]  +  0.25f * in[1];
-        out[2] = 0.5f  * in[0]  +  0.5f  * in[1];
-        out[3] = 0.25f * in[0]  +  0.75f * in[1];
+        const int32_t a = in[0];
+        const int32_t b = in[1];
+        out[0] = a;
+        out[1] = (3 * a + b) >> 2;
+        out[2] = (a + b) >> 1;
+        out[3] = (a + 3 * b) >> 2;
         in += 1;
         out += 4;
     }
@@ -314,7 +329,7 @@ inline void SamplerBase<Rate_6_0_Mhz, Rate_24_0_Mhz>::sample(const float* __rest
 */
 /*
 template<>
-inline void SamplerBase<Rate_10_0_Mhz, Rate_24_0_Mhz>::sample(const float* __restrict in, float* __restrict out) noexcept {
+inline void SamplerBase<Rate_10_0_Mhz, Rate_24_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
     constexpr float s = 1.0f / 12.0f;
     for (size_t i = 0; i < NumBlocks; i++) {
         out[0] = ( 7.0f * in[0] +  5.0f * in[1]) * s; 

--- a/include/SamplerFunc.hpp
+++ b/include/SamplerFunc.hpp
@@ -7,22 +7,26 @@
 #pragma once
 #include <numeric>
 #include <cstddef>
+#include <cstdint>
 #include <array>
 
 namespace SamplerFunc_details {
 
+    // interpolation weight in Q16, so the generic path stays integer
+    inline constexpr int WeightFracBits = 16;
+
     template<size_t RatioInput, size_t RatioOutput>
     constexpr auto makeLinearInterpTable() {
-        std::array<float, RatioOutput> alpha{};
+        std::array<int32_t, RatioOutput> alpha{};
         std::array<size_t, RatioOutput> k{};
 
         for (size_t j = 0; j < RatioOutput; j++) {
-            const float t = float(j) * float(RatioInput) / float(RatioOutput);
+            const double t = double(j) * double(RatioInput) / double(RatioOutput);
             const size_t ki = size_t(t);
-            const float a = t - float(ki);
+            const double a = t - double(ki);
 
             k[j] = ki;
-            alpha[j] = a;
+            alpha[j] = int32_t(a * double(1 << WeightFracBits) + 0.5);
         }
 
         return std::pair{k, alpha};
@@ -37,15 +41,18 @@ struct SamplerFunc {
     static constexpr auto& k = tbl.first;
     static constexpr auto& a = tbl.second;
 
-    static constexpr void sample(const float* __restrict in,
-                                 float* __restrict out) noexcept
+    static constexpr void sample(const int32_t* __restrict in,
+                                 int32_t* __restrict out) noexcept
     {
+        using namespace SamplerFunc_details;
         for (size_t i = 0; i < NumBlocks; i++) {
             for (size_t j = 0; j < RatioOutput; j++) {
-                const float alpha = a[j];
-                const float l = 1.0f - alpha;
-                const float r = alpha;
-                out[j] = l * in[k[j]] + r * in[k[j] + 1];
+                const int32_t r = a[j];
+                const int32_t l = (1 << WeightFracBits) - r;
+                // the samples carry 28 bits, so the weighted sum is widened
+                const int64_t acc = int64_t(l) * int64_t(in[k[j]])
+                                  + int64_t(r) * int64_t(in[k[j] + 1]);
+                out[j] = int32_t(acc >> WeightFracBits);
             }
             in  += RatioInput;
             out += RatioOutput;

--- a/include/ShiftRegisters.hpp
+++ b/include/ShiftRegisters.hpp
@@ -31,7 +31,6 @@ class alignas(16) ShiftRegistersBase {
             m_crc_112[i] = 0;
             m_high[i] = 0;
             m_low[i] = 0;
-            m_df[i] = 0;
         };
     }
 
@@ -43,8 +42,12 @@ class alignas(16) ShiftRegistersBase {
         return (CRC::crc_t)m_crc_112[i];
     }
 
+    /// The downlink format is the top five bits of the register, so keeping a
+    /// separate array for it meant storing NumStreams words every sample to
+    /// serve a read that only happens on a handled format. Derived here
+    /// instead, from the value the update has already written.
     constexpr uint32_t getDF(auto i) const noexcept{
-        return (uint32_t)m_df[i];
+        return (uint32_t)(m_high[i] >> 59);
     }
 
     protected:
@@ -58,8 +61,6 @@ class alignas(16) ShiftRegistersBase {
 
     // Each stream has a checksum for long messages (112 bit)
 	uint64_t m_crc_112[NumStreams];
-
-    uint64_t m_df[NumStreams];
 };
 
 
@@ -106,7 +107,6 @@ class alignas(16) ShiftRegisters : public ShiftRegistersBase<NumStreams> {
                 this->m_crc_112[i] = crc112;
                 this->m_high[i]    = newHigh;
                 this->m_low[i]     = newLow;
-                this->m_df[i]      = df;
 
                 handledMask |= uint64_t((handledDownlinkFormats >> df) & 0x1) << i;
             }

--- a/include/ShiftRegisters.hpp
+++ b/include/ShiftRegisters.hpp
@@ -35,11 +35,11 @@ class alignas(16) ShiftRegistersBase {
     }
 
     constexpr CRC::crc_t getCRC_56(auto i) const noexcept {
-        return (CRC::crc_t)m_crc_56[i];
+        return m_crc_56[i];
     }
 
     constexpr CRC::crc_t getCRC_112(auto i) const noexcept {
-        return (CRC::crc_t)m_crc_112[i];
+        return m_crc_112[i];
     }
 
     /// The downlink format is the top five bits of the register, so keeping a
@@ -55,12 +55,12 @@ class alignas(16) ShiftRegistersBase {
     uint64_t m_low[NumStreams];
     uint64_t m_high[NumStreams];
 
-	// And a checksum for the short messages (56 bit). Held in 64 bit so the
-	// masked update below needs no narrowing in the middle of the chain.
-	uint64_t m_crc_56[NumStreams];
+	// And a checksum for the short messages (56 bit). Never wider than 25 bits,
+	// so it is held in 32 and the update moves half the bytes it used to.
+	CRC::crc_t m_crc_56[NumStreams];
 
     // Each stream has a checksum for long messages (112 bit)
-	uint64_t m_crc_112[NumStreams];
+	CRC::crc_t m_crc_112[NumStreams];
 };
 
 
@@ -86,13 +86,13 @@ class alignas(16) ShiftRegisters : public ShiftRegistersBase<NumStreams> {
                 const uint64_t low  = this->m_low[i];
 
                 // all ones when a one bit leaves the register at the top
-                const uint64_t shiftedOut = uint64_t(0) - (high >> 63);
+                const uint32_t shiftedOut = uint32_t(0) - uint32_t(high >> 63);
 
-                uint64_t crc56  = this->m_crc_56[i]  ^ (Delta55  & shiftedOut);
-                uint64_t crc112 = this->m_crc_112[i] ^ (Delta111 & shiftedOut);
+                uint32_t crc56  = this->m_crc_56[i]  ^ (Delta55  & shiftedOut);
+                uint32_t crc112 = this->m_crc_112[i] ^ (Delta111 & shiftedOut);
 
-                crc56  = (crc56  << 1) | ((high >> 7)  & 0x1);
-                crc112 = (crc112 << 1) | ((low  >> 15) & 0x1);
+                crc56  = (crc56  << 1) | uint32_t((high >> 7)  & 0x1);
+                crc112 = (crc112 << 1) | uint32_t((low  >> 15) & 0x1);
 
                 const uint64_t newHigh = (high << 1) | (low >> 63);
                 const uint64_t newLow  = (low  << 1) | cmp[i];
@@ -100,8 +100,8 @@ class alignas(16) ShiftRegisters : public ShiftRegistersBase<NumStreams> {
 
                 // Fold the polynomial back in whenever bit 24 is set. The CRC
                 // never exceeds 25 bits here, so the shift is a 0/1 flag.
-                crc56  ^= Polynomial & (uint64_t(0) - (crc56  >> 24));
-                crc112 ^= Polynomial & (uint64_t(0) - (crc112 >> 24));
+                crc56  ^= Polynomial & (uint32_t(0) - (crc56  >> 24));
+                crc112 ^= Polynomial & (uint32_t(0) - (crc112 >> 24));
 
                 this->m_crc_56[i]  = crc56;
                 this->m_crc_112[i] = crc112;
@@ -123,8 +123,8 @@ class alignas(16) ShiftRegisters : public ShiftRegistersBase<NumStreams> {
         }
 
     private:
-        static constexpr uint64_t Delta55  = CRC::delta<55>();
-        static constexpr uint64_t Delta111 = CRC::delta<111>();
-        static constexpr uint64_t Polynomial = CRC::polynomial;
+        static constexpr CRC::crc_t Delta55  = CRC::delta<55>();
+        static constexpr CRC::crc_t Delta111 = CRC::delta<111>();
+        static constexpr CRC::crc_t Polynomial = CRC::polynomial;
 
 };

--- a/tests/SamplerTest.cpp
+++ b/tests/SamplerTest.cpp
@@ -1,21 +1,27 @@
 #include "Sampler.hpp"
 
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 int main() {
     using Sampler = Sampler_2_56_to_8_0_Mhz;
 
-    std::vector<float> input(Sampler::InputBufferSize + Sampler::InputBufferOverlap);
-    std::vector<float> output(Sampler::SampleBufferSize);
+    std::vector<int32_t> input(Sampler::InputBufferSize + Sampler::InputBufferOverlap);
+    std::vector<int32_t> output(Sampler::SampleBufferSize);
     for (size_t i = 0; i < input.size(); ++i)
-        input[i] = static_cast<float>(i);
+        input[i] = static_cast<int32_t>(i);
 
     Sampler::sample(input.data(), output.data());
 
+    // A ramp resampled by 8/25 comes back out as the same ramp. The weighted
+    // average now divides by 25 in integers, so each output is the exact value
+    // with the fraction dropped, which keeps the error below one. A wrong
+    // weight or denominator makes the error grow with the index instead, so
+    // this still catches the thing the test is here for.
     for (size_t i = 0; i < output.size(); ++i) {
-        const float expected = static_cast<float>(i) * 8.0f / 25.0f;
-        if (std::fabs(output[i] - expected) > 2e-3f)
+        const double expected = static_cast<double>(i) * 8.0 / 25.0;
+        if (std::fabs(static_cast<double>(output[i]) - expected) > 1.0)
             return 1;
     }
     return 0;


### PR DESCRIPTION
## Summary

Four independent changes to the signal path and the demodulator state, each measured on its own. Together they cut CPU by **24% on a Pi 4** and **15% on a Pi 5**, and the first three do not change a single decoded message.

Nothing here adds a thread, a dependency or a build option.

## Measurements

Same 60 s Airspy capture throughout, `-s 6 -u 24 -q`, `Release`. Each figure is the minimum of three repetitions, interleaved across all five builds rather than run in blocks — block-structured timing on a board that is also doing something else is confounded, and an earlier version of this measurement disagreed with the interleaved one by more than the effect being measured.

| commit | Pi 4 / Cortex-A72 | Pi 5 / Cortex-A76 | messages |
| --- | --- | --- | --- |
| *(baseline: current main)* | 47.61 s | 19.52 s | 31855 |
| derive the downlink format instead of storing it | -0.8% | -0.4% | 31855 |
| keep the CRCs in 32 bit again | **-5.5%** | -0.3% | 31855 |
| block based FIR and a vectorizable input path | -3.6% | **-9.2%** | 31855 |
| run the whole signal path in fixed point | **-15.4%** | -5.9% | 31853 |
| **cumulative** | **-23.6%** | **-15.2%** | |

Boards: Raspberry Pi 4 Model B (Cortex-A72, gcc 14) and Raspberry Pi 5 Model B (Cortex-A76, gcc 12).

**How much each change is worth depends strongly on the core.** Keeping the CRCs in 32 bit is worth 5.5% on the A72 and nothing on the A76; the block FIR is the other way round, 3.6% against 9.2%. I would not have predicted either, and it is part of why these are separate commits rather than one.

**The workload matters as much as the core.** The 24% figure is for a 6 Msps Airspy driving 24 phase streams. On an RTL-SDR recording at 2.4 Msps into 12 streams the same branch is worth about **-5%**, because there the DSP path is a much smaller share of the total and message decoding dominates. I would not want the headline read as a universal number.

## Effect on decoding

The first three commits are **output-identical** — same message count before and after, on every capture.

Only the fixed-point commit changes anything, and by very little. Measured on six recordings from three sites and two receiver types, so the spread is visible rather than hidden behind one number:

| capture | rate | main | this branch | |
| --- | --- | --- | --- | --- |
| Airspy 60 s | 6 Msps | 31855 | 31853 | -0.006% |
| Airspy 90 s | 6 Msps | 56937 | 56895 | -0.074% |
| Netherlands, 1260 msg/s | 2.4 Msps | 522794 | 522758 | -0.007% |
| Netherlands | 2.4 Msps | 149973 | 149983 | **+0.007%** |
| Brazil, 42 msg/s | 2.4 Msps | 10096 | 10096 | 0.000% |
| Brazil | 2.4 Msps | 3345 | 3344 | -0.030% |

The sign is not consistent, which is the point: what is left is fixed-point quantisation at the level of a handful of messages out of hundreds of thousands, not a systematic cost.

Getting there took some care. An earlier version of this branch also moved the sample ring to **squared** magnitude, to avoid a square root. Squaring is monotone, so it cannot flip a comparison — but the ring is what the resampler interpolates, and interpolation does not commute with squaring. On a busy 2.4 Msps feed that cost **0.5% of messages**, invisible on any Airspy capture because the wider margins there barely show it. That commit has been dropped and the magnitude is linear again, with 8 fractional bits kept, because truncating the root of a weak sample to an integer costs about 0.3% on its own.

## Notes for review

- **`Sampler.hpp`, 2.56 → 8 MHz**: this work started before the interpolation fix that changed the denominator from 24 to 25. The fixed-point version here carries that fix rather than reverting it: `mix(l, in[k], r, in[k+1], 25)`.
- **`tests/SamplerTest.cpp`** now uses `int32_t` buffers, since the sampler no longer takes floats. The tolerance is 1.0 rather than 2e-3 because the weighted average divides by 25 in integers and the exact value is truncated, so the dropped fraction is always below one. A wrong weight or denominator still makes the error grow with the index, so the test keeps the property it was written for.
- **8-bit input centring**: `convertFixed` now centres uc8 on 127.5 like `convertScalar` does, by doubling the sample before subtracting 255. Centring on 128 instead costs about 2.7% of messages on a real dongle — half an LSB is a large fraction of an eight bit sample, and the RTL-SDR `-q` pipeline has no DC removal to clean up after it.
- The fixed-point commit is by far the largest of the four and the one I would expect to take the most reading. It is also the most valuable on the A72. **If you would rather take the first three now and look at that one separately, they stand on their own at -9.7% on the A72 and -9.9% on the A76**, and none of them changes a single message.

## Validation

- `ctest`: 7/7 pass
- clean under AddressSanitizer and UndefinedBehaviorSanitizer, on both a 6 Msps Airspy and a 2.4 Msps RTL-SDR recording
- built and measured on both boards from this branch, not from a patched tree
- message counts compared directly on six recordings, not sampled
