### PR TITLE
Read live stdin with bulk read()

### DIFF
--- a/include/InputStreamReader.hpp
+++ b/include/InputStreamReader.hpp
@@ -7,6 +7,14 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <istream>
+#include <memory>
+#include <unistd.h>
+
 #include "InputReaderBase.hpp"
 template<typename RawFormat, size_t InputBufferSize, typename Pipeline>
 class InputStdStreamReader : public InputReaderBase<RawFormat, InputBufferSize, Pipeline> {
@@ -15,11 +23,16 @@ public:
 
     InputStdStreamReader(Pipeline& pipeline, std::istream& stream)
         : InputReaderBase<RawFormat, InputBufferSize, Pipeline>(pipeline),
-          m_stream(stream)
+          m_stream(&stream), m_fd(-1)
     {
-        constexpr size_t NumValuesToRead = 2 * InputBufferSize;
-        m_buffer = std::make_unique<RawType[]>(NumValuesToRead);
-        std::fill(m_buffer.get(), m_buffer.get() + NumValuesToRead, RawType(0));
+        allocateBuffer();
+    }
+
+    InputStdStreamReader(Pipeline& pipeline, int fd)
+        : InputReaderBase<RawFormat, InputBufferSize, Pipeline>(pipeline),
+          m_stream(nullptr), m_fd(fd)
+    {
+        allocateBuffer();
     }
 
     inline void readMagnitude(int32_t* out) {
@@ -27,8 +40,26 @@ public:
         constexpr size_t NumValuesToRead = 2 * N;
         constexpr size_t NumBytesToRead  = NumValuesToRead * sizeof(RawType);
 
-        m_stream.read(reinterpret_cast<char*>(m_buffer.get()), NumBytesToRead);
-        std::streamsize bytesRead = m_stream.gcount();
+        std::streamsize bytesRead = 0;
+        if (m_fd >= 0) {
+            char* p = reinterpret_cast<char*>(m_buffer.get());
+            size_t total = 0;
+            while (total < NumBytesToRead) {
+                const ssize_t n = ::read(m_fd, p + total, NumBytesToRead - total);
+                if (n < 0) {
+                    if (errno == EINTR)
+                        continue;
+                    break;
+                }
+                if (n == 0)
+                    break;
+                total += size_t(n);
+            }
+            bytesRead = std::streamsize(total);
+        } else {
+            m_stream->read(reinterpret_cast<char*>(m_buffer.get()), NumBytesToRead);
+            bytesRead = m_stream->gcount();
+        }
 
         if (bytesRead < std::streamsize(NumBytesToRead)) {
             std::memset(reinterpret_cast<char*>(m_buffer.get()) + bytesRead,
@@ -45,9 +76,15 @@ public:
     }
 
 private:
-    std::istream& m_stream;
+    void allocateBuffer() {
+        constexpr size_t NumValuesToRead = 2 * InputBufferSize;
+        m_buffer = std::make_unique<RawType[]>(NumValuesToRead);
+        std::fill(m_buffer.get(), m_buffer.get() + NumValuesToRead, RawType(0));
+    }
+
+    std::istream* m_stream;
+    int m_fd;
     std::unique_ptr<RawType[]> m_buffer;
     bool m_eof = false;
 };
-
 

--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <optional>
 #include <sstream>
+#include <unistd.h>
 
 
 template<typename Sampler>
@@ -257,7 +258,7 @@ public:
             RawFormatType,
             SamplerType::InputBufferSize,
             decltype(iqPipeline)
-        > inputReader(iqPipeline, std::cin);
+        > inputReader(iqPipeline, STDIN_FILENO);
 
         
         SampleStream<SamplerType> sampleStream;


### PR DESCRIPTION
## Summary

- read the CLI stdin path through its file descriptor with bulk `read()` calls
- retain the `std::istream` constructor for existing non-CLI consumers
- preserve partial-block zero filling and EOF behavior

## Why

On libc++, `std::istream::read()` walks the stream buffer one character at a
time through `getc`/`flockfile`. For a live IQ stream this dominated the CPU
cost of the complete pipeline. Reading the same blocks directly from stdin's
file descriptor removes that overhead without changing the DSP or decoder.

## Benchmark

Jenkins history benchmark on macOS, Release/Clang, using the same cached 6 Msps
IQ capture at 6 -> 12. These are adjacent runs before and after the equivalent
reader-only change in the integration history:

| | before | after | change |
| --- | ---: | ---: | ---: |
| messages | 33,136 | 33,136 | identical |
| CPU | 32.789 s | 19.209 s | -41.4% |
| wall | 29.122 s | 18.944 s | -35.0% |

The emitted AVR output was byte-identical.

## Validation

- Release build with AppleClang
- `ctest`: 7/7 passed
- stdin smoke test with a partial final block
- `git diff --check`
