### PR TITLE
Use sharpening cubic interpolation for RTL-SDR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MIN_SNR               2.5 CACHE STRING "Reject address-parity frames below t
 option(ENABLE_RTLSDR_BLOG    "Enable vendored RTL-SDR Blog fork" OFF)
 option(ENABLE_TOO_MUCH_CPU   "Unlocks the 40 and 48 Msps speeds" OFF)
 option(BUILD_TESTING         "Build tests" OFF)
+set(INTERPOLATION_KERNEL "6" CACHE STRING "RTL-SDR interpolation kernel (1 linear, 6 sharpening cubic)")
 
 set(STATS_DEF        STATS_ENABLED=$<BOOL:${ENABLE_STATS}>)
 set(STATS_END_DEF    STATS_END_ONLY=$<BOOL:${END_STATS}>)
@@ -31,6 +32,7 @@ set(PREAMBLE_GATE_DEF STREAM1090_PREAMBLE_GATE=$<BOOL:${ENABLE_PREAMBLE_GATE}>)
 set(PREAMBLE_THRESHOLD_DEF STREAM1090_PREAMBLE_THRESHOLD=${PREAMBLE_GATE_THRESHOLD})
 set(MIN_SNR_DEF         STREAM1090_MIN_SNR=${MIN_SNR})
 set(TOO_MUCH_CPU_DEF STREAM1090_TOO_MUCH_CPU=$<BOOL:${ENABLE_TOO_MUCH_CPU}>)
+set(INTERPOLATION_DEF STREAM1090_INTERP=${INTERPOLATION_KERNEL})
 
 # ------------------------------------------------------------
 # Compiler settings
@@ -143,6 +145,7 @@ target_compile_definitions(stream1090 PRIVATE
     ${PREAMBLE_GATE_DEF}
     ${PREAMBLE_THRESHOLD_DEF}
     ${MIN_SNR_DEF}
+    ${INTERPOLATION_DEF}
     ${DEVICE_DEFINITIONS}
 )
 
@@ -167,6 +170,8 @@ if(BUILD_TESTING)
     stream1090_add_test(sampler_test tests/SamplerTest.cpp)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
+    stream1090_add_test(sampler_interp_sharpening_test tests/SamplerInterpolationTest.cpp)
+    target_compile_definitions(sampler_interp_sharpening_test PRIVATE STREAM1090_INTERP=6)
 endif()
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ In a much nicer table, they look like this:
 |  10  |  10 | uint16 IQ | Airspy |
 |  10  |  24 | uint16 IQ | Airspy |
 
+The 2.4 → 12, 2.56 → 8 and 2.56 → 12 MHz RTL-SDR paths use a sharpening cubic
+interpolation kernel by default. Configure with `-DINTERPOLATION_KERNEL=1` to
+restore linear interpolation. Other rate combinations are unaffected.
+
 The rule of thumb here is simple: The higher the upsample rate, the more messages will be found, but at the cost of higher CPU usage.
 If you do not care about CPU usage, then use the highest upsample rate. For RTL-SDR this would be something like
 ```
@@ -179,6 +183,10 @@ or if your hardware supports 10 Msps sample rate
 ```
 ./build/stream1090 -s 10 -u 24 -d ./configs/airspy.ini > /dev/null
 ```
+
+Airspy upsampling from 10 MHz to 40 or 48 MHz is available only when the
+project is configured with `-DENABLE_TOO_MUCH_CPU=ON`. These presets require
+substantially more CPU and are therefore excluded from default builds.
 
 #### A note on RTL-SDR devices and 2.56 MHz
 In general it is assumed that 2.4 MHz is the highest reliable sample rate for an RTL-SDR device. However, after experiments with different sticks, it turned out that at 2.56 MHz, samples are dropped only once at the beginning. Afterwards, no sample loss has been observed.

--- a/include/Sampler.hpp
+++ b/include/Sampler.hpp
@@ -226,22 +226,6 @@ inline void SamplerBase<Rate_2_4_Mhz, Rate_8_0_Mhz>::sample(const int32_t* __res
     } 
 }
 
-// 2.56 Mhz to 8.0 Mhz (8 streams) upsampling function
-template<>
-inline void SamplerBase<Rate_2_56_Mhz, Rate_8_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {
-    for (size_t i = 0; i < NumBlocks; i++) {
-            for (int j = 0; j < 25; j++) {
-                const auto offset = 8 * j;
-                const auto k = offset / 25;
-                const auto l = 25 - (offset % 25);
-                const auto r = 25 - l;
-                out[j] = SamplerMix::mix((int32_t)l, in[k], (int32_t)r, in[k+1], 25);
-            }
-            in += 8;
-            out += 25;
-        }
-}
-
 // 6.0 Mhz to 16.0 Mhz (16 streams) upsampling function
 template<>
 inline void SamplerBase<Rate_6_0_Mhz, Rate_16_0_Mhz>::sample(const int32_t* __restrict in, int32_t* __restrict out) noexcept {

--- a/include/SamplerFunc.hpp
+++ b/include/SamplerFunc.hpp
@@ -10,10 +10,23 @@
 #include <cstdint>
 #include <array>
 
+#ifndef STREAM1090_INTERP
+#define STREAM1090_INTERP 1
+#endif
+
+#if STREAM1090_INTERP != 1 && STREAM1090_INTERP != 6
+#error "STREAM1090_INTERP must be 1 (linear) or 6 (sharpening cubic)"
+#endif
+
 namespace SamplerFunc_details {
 
     // interpolation weight in Q16, so the generic path stays integer
     inline constexpr int WeightFracBits = 16;
+
+    constexpr int32_t toFixedWeight(double value) noexcept {
+        const double scaled = value * double(1 << WeightFracBits);
+        return int32_t(scaled >= 0.0 ? scaled + 0.5 : scaled - 0.5);
+    }
 
     template<size_t RatioInput, size_t RatioOutput>
     constexpr auto makeLinearInterpTable() {
@@ -32,30 +45,102 @@ namespace SamplerFunc_details {
         return std::pair{k, alpha};
     }
 
+    constexpr double mitchell(double x, double b, double c) noexcept {
+        if (x < 0.0)
+            x = -x;
+        const double x2 = x * x;
+        const double x3 = x2 * x;
+        if (x < 1.0)
+            return ((12.0 - 9.0 * b - 6.0 * c) * x3
+                  + (-18.0 + 12.0 * b + 6.0 * c) * x2
+                  + (6.0 - 2.0 * b)) / 6.0;
+        if (x < 2.0)
+            return ((-b - 6.0 * c) * x3
+                  + (6.0 * b + 30.0 * c) * x2
+                  + (-12.0 * b - 48.0 * c) * x
+                  + (8.0 * b + 24.0 * c)) / 6.0;
+        return 0.0;
+    }
+
+    template<size_t RatioInput, size_t RatioOutput>
+    constexpr auto makeSharpeningCubicTable() {
+        constexpr double b = 0.0;
+        constexpr double c = 1.4;
+        std::array<std::array<int32_t, 4>, RatioOutput> weights{};
+        for (size_t j = 0; j < RatioOutput; ++j) {
+            const double t = double(j) * double(RatioInput) / double(RatioOutput);
+            const double alpha = t - double(size_t(t));
+            weights[j][0] = toFixedWeight(mitchell(alpha + 1.0, b, c));
+            weights[j][1] = toFixedWeight(mitchell(alpha,       b, c));
+            weights[j][2] = toFixedWeight(mitchell(1.0 - alpha, b, c));
+            weights[j][3] = toFixedWeight(mitchell(2.0 - alpha, b, c));
+        }
+        return weights;
+    }
+
 } // end of namespace
 
 template<size_t RatioInput, size_t RatioOutput, size_t NumBlocks>
 struct SamplerFunc {
 
+    static constexpr bool UseSharpeningCubic =
+        STREAM1090_INTERP == 6
+        && ((RatioInput == 1 && RatioOutput == 5)
+            || (RatioInput == 8 && RatioOutput == 25)
+            || (RatioInput == 16 && RatioOutput == 75));
+
     static constexpr auto tbl = SamplerFunc_details::makeLinearInterpTable<RatioInput, RatioOutput>();
     static constexpr auto& k = tbl.first;
     static constexpr auto& a = tbl.second;
 
+    static constexpr void sampleLinearBlock(const int32_t* __restrict in,
+                                            int32_t* __restrict out) noexcept
+    {
+        using namespace SamplerFunc_details;
+        for (size_t j = 0; j < RatioOutput; ++j) {
+            const int32_t r = a[j];
+            const int32_t l = (1 << WeightFracBits) - r;
+            const int64_t acc = int64_t(l) * int64_t(in[k[j]])
+                              + int64_t(r) * int64_t(in[k[j] + 1]);
+            out[j] = int32_t(acc >> WeightFracBits);
+        }
+    }
+
+#if STREAM1090_INTERP == 6
+    static constexpr auto weights =
+        SamplerFunc_details::makeSharpeningCubicTable<RatioInput, RatioOutput>();
+#endif
+
     static constexpr void sample(const int32_t* __restrict in,
                                  int32_t* __restrict out) noexcept
     {
-        using namespace SamplerFunc_details;
-        for (size_t i = 0; i < NumBlocks; i++) {
-            for (size_t j = 0; j < RatioOutput; j++) {
-                const int32_t r = a[j];
-                const int32_t l = (1 << WeightFracBits) - r;
-                // the samples carry 28 bits, so the weighted sum is widened
-                const int64_t acc = int64_t(l) * int64_t(in[k[j]])
-                                  + int64_t(r) * int64_t(in[k[j] + 1]);
-                out[j] = int32_t(acc >> WeightFracBits);
-            }
+#if STREAM1090_INTERP == 6
+        if constexpr (UseSharpeningCubic) {
+            sampleLinearBlock(in, out);
             in  += RatioInput;
             out += RatioOutput;
+            for (size_t i = 1; i + 1 < NumBlocks; ++i) {
+                for (size_t j = 0; j < RatioOutput; ++j) {
+                    const int32_t* p = in + k[j];
+                    const int64_t acc = int64_t(weights[j][0]) * int64_t(p[-1])
+                                      + int64_t(weights[j][1]) * int64_t(p[0])
+                                      + int64_t(weights[j][2]) * int64_t(p[1])
+                                      + int64_t(weights[j][3]) * int64_t(p[2]);
+                    out[j] = int32_t(acc >> SamplerFunc_details::WeightFracBits);
+                }
+                in  += RatioInput;
+                out += RatioOutput;
+            }
+            sampleLinearBlock(in, out);
+        } else {
+#endif
+            for (size_t i = 0; i < NumBlocks; i++) {
+                sampleLinearBlock(in, out);
+                in  += RatioInput;
+                out += RatioOutput;
+            }
+#if STREAM1090_INTERP == 6
         }
+#endif
     }
 };

--- a/tests/SamplerInterpolationTest.cpp
+++ b/tests/SamplerInterpolationTest.cpp
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "SamplerFunc.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+int main() {
+    constexpr size_t RatioInput = 1;
+    constexpr size_t RatioOutput = 5;
+    constexpr size_t NumBlocks = 16;
+    static_assert(SamplerFunc<1, 5, NumBlocks>::UseSharpeningCubic);
+    static_assert(SamplerFunc<8, 25, NumBlocks>::UseSharpeningCubic);
+    static_assert(SamplerFunc<16, 75, NumBlocks>::UseSharpeningCubic);
+    static_assert(!SamplerFunc<2, 5, NumBlocks>::UseSharpeningCubic);
+    std::array<int32_t, RatioInput * NumBlocks + 1> input{};
+    std::array<int32_t, RatioOutput * NumBlocks> output{};
+
+    for (size_t i = 0; i < input.size(); ++i)
+        input[i] = int32_t(i * 1000);
+
+    SamplerFunc<RatioInput, RatioOutput, NumBlocks>::sample(input.data(), output.data());
+
+    bool differsFromLinear = false;
+    for (size_t i = 0; i < output.size(); ++i) {
+        const double expected = double(i) * double(RatioInput) * 1000.0
+                              / double(RatioOutput);
+        differsFromLinear |= std::fabs(double(output[i]) - expected) > 4.0;
+    }
+
+    if (!differsFromLinear) {
+        std::cerr << "selected kernel produced the linear result\n";
+        return 1;
+    }
+
+    input.fill(100000);
+    output.fill(0);
+    SamplerFunc<RatioInput, RatioOutput, NumBlocks>::sample(input.data(), output.data());
+    for (size_t i = 0; i < output.size(); ++i) {
+        if (std::abs(output[i] - 100000) > 8) {
+            std::cerr << "constant sample " << i << ": got " << output[i] << '\n';
+            return 1;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
## What changed

- add a fixed-point four-tap sharpening cubic interpolation kernel;
- use it by default only for the validated RTL-SDR paths: 2.4 to 12, 2.56 to 8, and 2.56 to 12 MHz;
- remove the dedicated 2.56 to 8 MHz linear sampler so that path uses the shared implementation;
- keep `-DINTERPOLATION_KERNEL=1` as a linear-interpolation fallback;
- add sampler coverage and document the behavior.

Other rate combinations remain linear.

## Why

The cubic kernel improves message recovery on the available native RTL-SDR captures. A sharpening value of 1.4 was selected because every tested 2.4 to 12 MHz window improved; stronger values produced a slightly larger aggregate result but regressed one low-traffic window by one message.

## Replay results

The 2.4 MSPS corpus contains 27 five-second native RTL-SDR windows from nine recordings. The 2.56 MSPS corpus contains six independent ten-second windows split into training and validation sets.

| Path | Upstream | Proposed | Delta | Per-window result |
|---|---:|---:|---:|---|
| 2.4 to 8 MHz | 86,646 | 86,646 | 0.00% | 27 equal, 0 worse |
| 2.4 to 12 MHz | 89,853 | 92,714 | +3.18% | 27 better, 0 worse |
| 2.56 to 8 MHz | 48,756 | 49,115 | +0.74% | 6 better, 0 worse |
| 2.56 to 12 MHz | 49,641 | 50,150 | +1.03% | 6 better, 0 worse |

## Raspberry Pi 4 CPU

Release builds with GCC 14, median of three alternating runs:

| Path | Upstream CPU | Proposed CPU | Delta |
|---|---:|---:|---:|
| 2.4 to 8 MHz | 35.069 s | 35.030 s | -0.11% |
| 2.4 to 12 MHz | 47.577 s | 47.653 s | +0.16% |
| 2.56 to 8 MHz | 19.306 s | 17.983 s | -6.85% |
| 2.56 to 12 MHz | 23.727 s | 24.826 s | +4.63% |

The Pi remained below 59 C and reported no throttling. At the most expensive setting, 2.56 to 12 MHz, CPU use increased from about 39.5% to 41.4% of one core.

## Checks

- rebased onto current upstream `main`, including the shared CMake test helper;
- Apple Clang 21 Release build and 10/10 tests;
- prior GCC 15 and sanitizer validation remains applicable to the interpolation change;
- GCC 14 Release builds and replay benchmarks on Raspberry Pi 4;
- no message-count regression in any tested RTL-SDR window.
