### PR TITLE
Flush the AVR output on a cadence instead of once per frame

### DIFF
--- a/include/AVRWriter.hpp
+++ b/include/AVRWriter.hpp
@@ -31,6 +31,19 @@ public:
         std::ios::sync_with_stdio(false);
     }
 
+    /// Push whatever is buffered to the underlying stream.
+    ///
+    /// The write functions deliberately do not flush. A frame is 30 or 44
+    /// bytes, so flushing every one of them turns a 20 kB/s feed into ~450
+    /// pieces per second, and each piece costs a write here plus a read and a
+    /// write in whatever relays the pipe. Measured on a Pi 4 feeding readsb
+    /// through socat: 2270 reads and 2270 writes in five seconds inside socat,
+    /// 4.3% of a core, to move 20 kB/s. SampleStream flushes on a fixed
+    /// cadence instead.
+    void flush() {
+        m_out.flush();
+    }
+
     // Writes an AVR short frame with MLAT timestamp (no RSSI)
     void write_short_MLAT(uint64_t ts, uint64_t frameShort) {
         char* p = m_buf;
@@ -42,7 +55,6 @@ public:
         *p++ = '\n';
 
         m_out.write(m_buf, p - m_buf);
-        m_out.flush();
     }
 
     // Writes an AVR long frame with MLAT timestamp (no RSSI)
@@ -57,7 +69,6 @@ public:
         *p++ = '\n';
 
         m_out.write(m_buf, p - m_buf);
-        m_out.flush();
     }
 
     // Writes an AVR short frame with MLAT timestamp and RSSI
@@ -72,7 +83,6 @@ public:
         *p++ = '\n';
 
         m_out.write(m_buf, p - m_buf);
-        m_out.flush();
     }
 
     // Writes an AVR long frame with MLAT timestamp and RSSI
@@ -88,7 +98,6 @@ public:
         *p++ = '\n';
 
         m_out.write(m_buf, p - m_buf);
-        m_out.flush();
     }
 
 private:

--- a/include/MessageHandler.hpp
+++ b/include/MessageHandler.hpp
@@ -33,6 +33,10 @@ public:
         m_writer.write_long_MLAT(MLAT_timeStamp, frame);
     }
 
+    void flush() {
+        m_writer.flush();
+    }
+
     AVRWriter m_writer;
 };
 
@@ -59,6 +63,10 @@ public:
         const uint64_t MLAT_timeStamp = MLAT::sampleIndexToMlatTime<Sampler::NumStreams>(sampleIndex);
         const uint8_t rssi = rssiProvider.getRSSILong();
         m_writer.write_long_MLAT_RSSI(MLAT_timeStamp, frame, rssi);
+    }
+
+    void flush() {
+        m_writer.flush();
     }
 
 private:

--- a/include/SampleStream.hpp
+++ b/include/SampleStream.hpp
@@ -22,6 +22,17 @@ public:
     static constexpr size_t NumSampleBuffers = 2;
     static constexpr size_t TotalSampleBufferLength = NumSampleBuffers * Sampler::SampleBufferSize + Sampler::SampleBufferOverlap;
 
+    // How long a decoded frame may sit in the output buffer before it is
+    // pushed out. Ten milliseconds is below anything downstream notices - a
+    // tracker sees aircraft at 2 Hz, and MLAT reads the timestamp carried
+    // inside the frame rather than the arrival time of the bytes - and it
+    // batches roughly six frames per flush at a busy site.
+    static constexpr size_t FlushIntervalMicros = 10000;
+    // a block is SampleBufferSize / NumStreams bit periods, i.e. microseconds
+    static constexpr size_t BlockMicros = Sampler::SampleBufferSize / Sampler::NumStreams;
+    static constexpr size_t FlushEveryBlocks =
+        (FlushIntervalMicros + BlockMicros - 1) / BlockMicros;
+
     SampleStream() : m_inputRingBuffer(0), m_sampleRingBuffer(0) { }
    
     // the main method that streams from InputStream using inputReader
@@ -90,6 +101,7 @@ private:
     BlockRing<int32_t, Sampler::SampleBufferSize, NumSampleBuffers, Sampler::SampleBufferOverlap> m_sampleRingBuffer;
     // not nice. Will change
     const int32_t* m_demodPos = nullptr;
+    size_t m_blocksSinceFlush = 0;
 };
 
 
@@ -151,6 +163,23 @@ inline void SampleStream<Sampler>::read(InputReaderType& inputReader, Handler& m
                 m_demodPos += Sampler::NumStreams;
             }
             m_sampleRingBuffer.advanceReadPos();
+
+            // Hand the buffered frames to the operating system on a fixed
+            // cadence rather than one frame at a time. The block boundary is
+            // already on this thread, so nothing has to be locked, and it
+            // ticks with the samples rather than with the traffic: a lone
+            // frame at a quiet site still leaves within FlushIntervalMicros,
+            // which a timer could only manage by flushing the stream from a
+            // second thread.
+            if (++m_blocksSinceFlush >= FlushEveryBlocks) {
+                m_blocksSinceFlush = 0;
+                if constexpr (requires { messageHandler.flush(); })
+                    messageHandler.flush();
+            }
         }
     }
+
+    // and whatever is left over when the input ends
+    if constexpr (requires { messageHandler.flush(); })
+        messageHandler.flush();
 }


### PR DESCRIPTION
`AVRWriter` flushes after every write, so the output leaves the process one
frame at a time. A frame is 30 or 44 bytes, so a 20 kB/s feed becomes about 450
pieces per second, and each piece costs a write here plus a read and a write in
anything relaying the pipe.

This flushes on a cadence instead: the writers stop flushing, and `SampleStream`
flushes at the block boundary every `FlushEveryBlocks` blocks, sized from the
sampler so the interval is roughly ten milliseconds for any rate combination
(8 blocks at 6->24, 13 at 10->24, 3 at 2.4->12).

### Why the block boundary rather than a timer

The block boundary is already on the demodulating thread, so nothing has to be
locked, and it ticks with the samples rather than with the traffic - a lone
frame at a quiet site still leaves within the interval. A timer could only do
the same by flushing the stream from a second thread, which is what `main()`
takes care to avoid when it unties `cin` and `cerr`.

### Measurements

Counting the reads a consumer sees, on 60 s captures. Output is **byte-identical**
in every case:

| rate | pieces before | after | pieces/s after |
| --- | --- | --- | --- |
| 6 -> 24 | 28514 | 5425 | 90 |
| 10 -> 24 | 60195 | 4989 | 93 |
| 2.56 -> 12 | 37232 | 4588 | 77 |
| 6 -> 12 | 27596 | 5440 | 91 |

The reduction factor varies with traffic (5.1x to 12.1x) but the resulting rate
does not: all four land at 77-93 pieces per second against the 100/s cadence.
The syscall rate is now set by the cadence instead of by the traffic, so a
busier site batches more rather than costing more.

This is the cheap measurement to reproduce - any capture plus a reader that
counts `read()` calls.

On a Pi 4 (Cortex-A72, gcc 14) feeding a socat relay into a TCP sink, best of
three interleaved runs over 12.5 s of signal:

| | total CPU (demod + relay) | demod alone |
| --- | --- | --- |
| before | 9.239 s | 7.889 s |
| after | **8.561 s** | 7.850 s |

The demodulator itself is unchanged, so the saving is in the relay: its share
falls from 1.350 s to 0.711 s. On a long-running deployment, read from the
process counters over six days, socat had accumulated 4.3% of a core against
the demodulator's 79.8% - this roughly halves that.

### Things worth flagging

**This changes observable behaviour.** A frame can now sit in the buffer for up
to ~10 ms. That is below what anything downstream can act on - a tracker sees
each aircraft about twice a second, and MLAT reads the timestamp carried inside
the frame rather than the arrival time of the bytes - but anyone reading the
stream line by line and synchronously will see it.

**The handler flush is picked up with a `requires` clause** rather than added to
the `MessageHandler` concept, so that a handler without one still compiles (the
test handler does not have it). That idiom is not used anywhere else in this
tree, so if you would rather have `flush()` in the concept and the handlers
updated, say so and I will change it - the explicit contract is arguably better
for a header library.

**Ten milliseconds is a conservative default, not a tuned one.** No sweep behind
it; it is the smallest interval that still gets most of the benefit.

**Not verified against a real decoder.** The relay measurement used a socat sink
that discards. A real consumer would also see 5-12x fewer, larger reads, so the
figure above is a lower bound on the system-wide saving, but that part is an
extrapolation.

The read loop flushes once more when the input ends, so a partial batch is not
lost at EOF. `ctest` passes 7/7.
