### PR TITLE
Reject unknown address parity before dispatch

### DIFF
--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -60,6 +60,10 @@ public:
 			const auto i = std::countr_zero(handledStreams);
 			// handleStream() looks at m_currTime, so keep it in step
 			m_currTime = baseTime + i;
+			if (addressParityRejects(uint32_t(i))) {
+				handledStreams &= handledStreams - 1;
+				continue;
+			}
 			handleStream(i);
 			handledStreams &= handledStreams - 1;
 		}
@@ -156,6 +160,29 @@ public:
 		
 		m_prevLongFrame = frameLong;
 		return false;
+	}
+
+	/// Reject address-parity candidates whose syndrome is not a cached address
+	/// before entering the dispatcher. Keep the phase deduplication state in
+	/// step exactly as the corresponding handler would have done.
+	bool addressParityRejects(uint32_t streamIndex) noexcept {
+		const auto df = m_shiftRegisters.getDF(streamIndex);
+		const bool isShort = (df == 0) || (df == 4) || (df == 5);
+		const bool isLong = (df == 16) || (df == 20) || (df == 21);
+		if (!isShort && !isLong)
+			return false;
+
+		const CRC::crc_t syndrome = isShort
+			? m_shiftRegisters.getCRC_56(streamIndex)
+			: m_shiftRegisters.getCRC_112(streamIndex);
+		if (syndrome != 0 && m_cache.find(syndrome).isValid())
+			return false;
+
+		if (isShort)
+			phaseDupCheckShort(m_shiftRegisters.extractAlignedFrameShort(streamIndex));
+		else
+			phaseDupCheckLong(m_shiftRegisters.extractAlignedFrameLong(streamIndex));
+		return true;
 	}
 
 	// Dispatcher function for handling messages based on the downlink format  


### PR DESCRIPTION
## Summary

Reject DF 0, 4, 5, 16, 20 and 21 candidates whose syndrome is not a cached
aircraft address before entering the message dispatcher.

The rejected candidate still updates the phase-deduplication state exactly as
the corresponding handler would. Candidates that pass the early check continue
through the existing handlers unchanged.

## Why

These six downlink formats carry the transponder address overlaid on their
parity. A valid frame's syndrome must therefore match an address already in the
ICAO cache.

The downlink-format gate also admits many random bit positions. Before this
change, every such address-parity candidate entered `handleStream()`, passed
through the format switch and entered its handler before the cache lookup
rejected it.

The early check performs the same CRC and cache lookup before dispatch. On the
noise path this avoids the switch and handler prologue.

The phase deduplication is stateful and normally runs before the syndrome check.
Skipping it changed which neighbouring phase of a real message survived and
could shift its timestamp. The early-rejection path therefore calls the same
short or long phase-deduplication function before dropping the candidate.
Candidates are deduplicated exactly once: here when rejected, or in the handler
when retained.

## Raspberry Pi 4 benchmark

Release build with GCC 14 on a Cortex-A72, using a real 6 MSPS Airspy capture at
`-s 6 -u 24 -q`.

Five 30-second runs per variant were interleaved and pinned to the same core.
The board continued running its normal ADS-B workload, so CPU time is reported
instead of wall time.

| | Upstream | Proposed | Delta |
|---|---:|---:|---:|
| Median total CPU | 19.584 s | 19.157 s | **-2.18%** |
| Median user CPU | 18.600 s | 18.256 s | **-1.85%** |

Every benchmark run produced byte-identical output. A separate replay of the
complete 60-second capture was also byte-identical.

The board remained near 50 C and reported no throttling.

## Validation

- Apple Clang 21 Release build with warnings treated as errors;
- 7/7 CTest tests pass on macOS;
- GCC 14 Release build and 7/7 tests pass on ARM;
- byte-identical output on every benchmark run;
- byte-identical output on the complete 60-second capture;
- `git diff --check` passes with the repository's CRLF files accounted for.
