### PR TITLE
Answer CRC error table misses from an occupancy bitmap

### DIFF
--- a/include/CRCErrorTable.hpp
+++ b/include/CRCErrorTable.hpp
@@ -18,7 +18,7 @@ namespace CRC {
 	template<size_t size, bool resolveCollisions = false>
 	class BaseErrorTable {
 	public:
-		constexpr BaseErrorTable() : m_keys(), m_ops() {
+		constexpr BaseErrorTable() : m_keys(), m_ops(), m_occupied() {
 			for (size_t i = 0; i < size; i++) {
 				m_keys[i] = 0x0;
 				m_ops[i] = fixop_t({0,0});
@@ -27,6 +27,14 @@ namespace CRC {
 		
 		constexpr fixop_t lookup(crc_t crc) const noexcept {
 			size_t index = crc % size;
+			// The tables live on the bad-message path, which in practice is fed
+			// noise syndromes: the overwhelming majority of lookups are misses
+			// and have to touch nothing but a miss filter. The home slot of a
+			// bucket can only hold an entry the moment something lands in that
+			// bucket (a collision chains off the home slot), so a clear bit
+			// settles the lookup without reading m_keys at all.
+			if (!isOccupied(index))
+				return fixop_t({0,0});
 			if constexpr (!resolveCollisions) {
 				if (m_keys[index] == crc) {
 					return m_ops[index];
@@ -60,11 +68,13 @@ namespace CRC {
 				if (m_keys[index] == 0) {
 					m_keys[index] = crc;
 					m_ops[index] = op;
+					setOccupied(index);
 				}
 			} else {
 				if (m_keys[index] == 0) {
 					m_keys[index] = crc;
 					m_ops[index] = op;
+					setOccupied(index);
 					return;
 				}
 				if ((m_keys[index] & ~collisionFlag) == crc) {
@@ -77,6 +87,7 @@ namespace CRC {
 					if (m_keys[index] == 0) {
 						m_keys[index] = crc;
 						m_ops[index] = op;
+						setOccupied(index);
 						return;
 					}
 					if ((m_keys[index] & ~collisionFlag) == crc) {
@@ -91,6 +102,20 @@ namespace CRC {
 		static constexpr crc_t collisionFlag = crc_t{1} << 31;
 		std::array<crc_t, size> m_keys;	
 		std::array<fixop_t, size> m_ops;
+
+		// One bit per slot mirroring "a key lives here", so a miss never has to
+		// touch m_keys. The DF17 table is 6790 slots, so this is under a
+		// kilobyte and stays in L1.
+		static constexpr size_t wordCount = (size + 63) / 64;
+		std::array<uint64_t, wordCount> m_occupied;
+
+		constexpr bool isOccupied(size_t index) const noexcept {
+			return (m_occupied[index >> 6] >> (index & 63)) & 0x1;
+		}
+
+		constexpr void setOccupied(size_t index) noexcept {
+			m_occupied[index >> 6] |= (uint64_t(1) << (index & 63));
+		}
 	};
 
 	// Error correction table used for extended squitter messages


### PR DESCRIPTION
## Summary

- add an exact occupancy bitmap in front of the CRC error-table key arrays
- reject empty home buckets without reading the larger key table
- keep the bitmap synchronized as constexpr tables are populated
- preserve lookup and error-correction behavior

## Why

The DF17 and DF11 error tables are queried on the bad-message path. In
practice, noise produces effectively random CRC syndromes, so the overwhelming
majority of lookups miss.

The DF17 key array is about 27 KiB and does not fit in the Cortex-A72 L1 data
cache. Previously, even a miss had to read that array before it could be
rejected.

The new bitmap mirrors whether a key occupies each slot. An entry can only
appear in a collision chain after its home slot has been occupied, so a clear
bit for the home slot is an exact negative result, not a probabilistic filter.
The DF17 bitmap is 856 bytes; including DF11, the total added bitmap storage is
920 bytes.

This is the same exact negative-filter pattern used for the ICAO cache in #29,
applied to the CRC syndrome tables.

## Raspberry Pi 4 benchmark

Measured on `rpi243`, a Raspberry Pi 4 with Cortex-A72 cores, using GCC 14.2
Release builds from current `origin/main` (`1285cf6`) and this PR (`e6306f4`).
Statistics were disabled to match the benchmark setup used for #29.

Both variants replayed the same 29.9-second Airspy U16-real capture at 6 Msps,
demodulated at 24 MHz with the built-in FIR. Eight measured runs per variant
were alternated in ABBA order after one warm-up per binary. The process was
restricted to cores 0, 1 and 3 because the production demodulator was pinned to
core 2.

Temperature stayed between 51.1 and 53.1 °C and `get_throttled` remained
`0x0`.

| Metric | Baseline mean | Bitmap mean | Difference |
| --- | ---: | ---: | ---: |
| User CPU time | 18.379 s | 17.982 s | **-2.16%** |
| CPU time (user + sys) | 19.286 s | 18.855 s | **-2.24%** |
| Median CPU time | 19.182 s | 18.758 s | **-2.21%** |

The paired 95% confidence interval for the user-CPU improvement was
1.08%-3.24%.

A separate two-run-per-variant `perf stat` check with the default statistics
build showed:

| Metric | Baseline mean | Bitmap mean | Difference |
| --- | ---: | ---: | ---: |
| L1 data-cache misses | 156.9 M | 94.5 M | **-39.8%** |
| L1 data-cache loads | 11.108 G | 11.031 G | -0.70% |
| Instructions | 34.119 G | 33.953 G | -0.49% |
| Cycles | 27.430 G | 26.616 G | -2.97% |

The replay output was byte-identical: 585,770 bytes with SHA-256
`8378e852befafc4739e2d9a11c43c8ce528ea1d73e82f98715437b45d5b171eb`
for every run.

## Validation

- clean Release build with AppleClang
- local test suite: 7/7 passed
- clean ARM64 Release builds with GCC 14.2
- ARM64 test suite: 7/7 passed for both variants
- byte-identical replay output on `rpi243`
