### PR TITLE
Reject noise-fabricated address-parity frames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ option(ENABLE_STATS          "Compile with STATS_ENABLED" ON)
 option(END_STATS             "Compile with STATS_END_ONLY" OFF)
 option(ENABLE_CUSTOM_INPUT   "Compile with STREAM1090_CUSTOM_INPUT" OFF)
 option(ENABLE_RSSI           "Compile with STREAM1090_ENABLE_RSSI" ON)
+option(ENABLE_PREAMBLE_GATE  "Reject address-parity frames that are weak and preamble-less" ON)
+set(PREAMBLE_GATE_THRESHOLD 1.2 CACHE STRING "Preamble score a real transmission must reach")
+set(MIN_SNR               2.5 CACHE STRING "Reject address-parity frames below this signal-to-noise ratio (0 disables; a ratio, so it transfers between receivers)")
 option(ENABLE_RTLSDR_BLOG    "Enable vendored RTL-SDR Blog fork" OFF)
 option(ENABLE_TOO_MUCH_CPU   "Unlocks the 40 and 48 Msps speeds" OFF)
 option(BUILD_TESTING         "Build tests" OFF)
@@ -24,6 +27,9 @@ set(STATS_DEF        STATS_ENABLED=$<BOOL:${ENABLE_STATS}>)
 set(STATS_END_DEF    STATS_END_ONLY=$<BOOL:${END_STATS}>)
 set(CUSTOM_INPUT_DEF STREAM1090_CUSTOM_INPUT=$<BOOL:${ENABLE_CUSTOM_INPUT}>)
 set(RSSI_DEF         STREAM1090_RSSI=$<BOOL:${ENABLE_RSSI}>)
+set(PREAMBLE_GATE_DEF STREAM1090_PREAMBLE_GATE=$<BOOL:${ENABLE_PREAMBLE_GATE}>)
+set(PREAMBLE_THRESHOLD_DEF STREAM1090_PREAMBLE_THRESHOLD=${PREAMBLE_GATE_THRESHOLD})
+set(MIN_SNR_DEF         STREAM1090_MIN_SNR=${MIN_SNR})
 set(TOO_MUCH_CPU_DEF STREAM1090_TOO_MUCH_CPU=$<BOOL:${ENABLE_TOO_MUCH_CPU}>)
 
 # ------------------------------------------------------------
@@ -134,6 +140,9 @@ target_compile_definitions(stream1090 PRIVATE
     ${CUSTOM_INPUT_DEF}
     ${RSSI_DEF}
     ${TOO_MUCH_CPU_DEF}
+    ${PREAMBLE_GATE_DEF}
+    ${PREAMBLE_THRESHOLD_DEF}
+    ${MIN_SNR_DEF}
     ${DEVICE_DEFINITIONS}
 )
 

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -47,6 +47,46 @@ public:
 		m_confidenceFn = fn;
 	}
 
+	using PreambleFn = float(*)(const void*, size_t);
+	void setPreambleSource(const void* ctx, PreambleFn fn) noexcept {
+		m_preambleCtx = ctx;
+		m_preambleFn = fn;
+	}
+
+	using SnrFn = float(*)(const void*, uint8_t);
+	void setSnrSource(const void* ctx, SnrFn fn) noexcept {
+		m_snrCtx = ctx;
+		m_snrFn = fn;
+	}
+
+#ifndef STREAM1090_MIN_SNR
+#define STREAM1090_MIN_SNR 0
+#endif
+	static constexpr float MinSnr = STREAM1090_MIN_SNR;
+
+	/// True when the frame's signal is not clearly above its local noise floor.
+	/// This is a ratio, so it transfers between receivers; 0 disables the test.
+	bool signalAtNoiseFloor(int streamIndex) noexcept {
+		if constexpr (MinSnr <= 0.0f)
+			return false;
+		if (m_snrFn == nullptr)
+			return false;
+		return m_snrFn(m_snrCtx, 56) < MinSnr;
+	}
+
+	/// True when the preamble in front of this candidate is strong enough to be
+	/// a real transmission. Disabled unless STREAM1090_PREAMBLE_GATE is defined.
+	bool preambleConfirms(int streamIndex) noexcept {
+	#if defined(STREAM1090_PREAMBLE_GATE) && STREAM1090_PREAMBLE_GATE
+		if (m_preambleFn == nullptr)
+			return false;
+		return m_preambleFn(m_preambleCtx, size_t(streamIndex))
+			>= float(STREAM1090_PREAMBLE_THRESHOLD);
+	#else
+		return false;
+	#endif
+	}
+
 	void shiftInNewBits(uint32_t* cmp) {
 		// the shift registers tell us which streams ended up on a downlink
 		// format we handle. That is a rare event, so most calls leave here
@@ -72,7 +112,7 @@ public:
 		logStats(Stats::NUM_ITERATIONS);
 	}
 
-	bool sendFrameLongAligned(int,
+	bool sendFrameLongAligned(int streamIndex,
 							  const uint8_t downlinkFormat, 
 							  CRC::crc_t crc,
 							  const Bits128& frame, 
@@ -83,6 +123,18 @@ public:
 		    e.last_time = m_currTime;
     		logStatsDup(downlinkFormat);
     		return false;
+		}
+
+		// Address-parity frames (DF16/20/21) carry no checkable CRC, so the
+		// payload checks are all they have, and a noise frame can pass them by
+		// coincidence (a parity that matches a cached address plus a plausible
+		// altitude). Reject the ones that are ALSO at the local noise floor with
+		// no preamble in front of them: both are ratios, so the test transfers
+		// between receivers. DF17/18 reach here with a checkable CRC and are
+		// not gated.
+		if ((downlinkFormat == 16 || downlinkFormat == 20 || downlinkFormat == 21)
+				&& signalAtNoiseFloor(streamIndex) && !preambleConfirms(streamIndex)) {
+			return false;
 		}
 
 		if ((downlinkFormat == 20) || (downlinkFormat == 16)) {
@@ -111,13 +163,20 @@ public:
 		return true;
 	}
 
-	bool sendFrameShortAligned(int, const uint8_t downlinkFormat, CRC::crc_t crc, const uint64_t& frameShort, const ICAOTable::Iterator& it) {
+	bool sendFrameShortAligned(int streamIndex, const uint8_t downlinkFormat, CRC::crc_t crc, const uint64_t& frameShort, const ICAOTable::Iterator& it) {
 		auto& e = m_cache.getMsgStatEntry(it);
 		static constexpr uint64_t DUP_WINDOW_TICKS = 30 * NumStreams;
 		if ((m_currTime - e.last_time) < DUP_WINDOW_TICKS) {
 		    e.last_time = m_currTime;
     		logStatsDup(downlinkFormat);
     		return false;
+		}
+
+		// Same rationale as the long path: DF0/4/5 recover the address from the
+		// parity, so reject frames at the noise floor with no preamble.
+		if ((downlinkFormat == 0 || downlinkFormat == 4 || downlinkFormat == 5)
+				&& signalAtNoiseFloor(streamIndex) && !preambleConfirms(streamIndex)) {
+			return false;
 		}
 
 		if ((downlinkFormat == 4) || (downlinkFormat == 0)) {
@@ -448,6 +507,13 @@ public:
 		const auto crc = m_shiftRegisters.getCRC_56(streamIndex);
 	
 		if (crc == 0) {
+			// A 24-bit CRC passes on noise about once per 16M candidate windows,
+			// and each such DF11 inserts an address that then licenses
+			// address-parity frames of its own. Reject the noise-floor,
+			// preamble-less ones to break that loop.
+			if (signalAtNoiseFloor(streamIndex) && !preambleConfirms(streamIndex)) {
+				return false;
+			}
 			logStats(Stats::DF11_ICAO_CA_FOUND_GOOD_CRC);
 			return handleDF11ShortMessageWithZeroCRC(streamIndex, frameShort, false);
 		} else if (crc < 80) {
@@ -493,6 +559,10 @@ public:
 private:
 	const void* m_confidenceCtx = nullptr;
 	ConfidenceFn m_confidenceFn = nullptr;
+	const void* m_preambleCtx = nullptr;
+	PreambleFn m_preambleFn = nullptr;
+	const void* m_snrCtx = nullptr;
+	SnrFn m_snrFn = nullptr;
 
 
 #if defined(STATS_ENABLED) && STATS_ENABLED

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <cstdlib>
+#include <limits>
 #include <memory>
 
 class ICAOTable {
@@ -24,6 +25,7 @@ public:
 	static constexpr uint32_t RejectedCandidateMaxTicks { 2'000'000 };
 	//static constexpr auto ALT_delta_25ft { 80 };
 	static constexpr auto ALT_delta_ft { 2000 };
+	static constexpr auto AltitudeUnset { std::numeric_limits<int16_t>::min() };
     // number if bits used for the look up table 
 	static constexpr auto NumBits { 16 };
 
@@ -82,7 +84,8 @@ public:
 		std::fill(m_table.get(), m_table.get() + Size, Entry{0x0, 0, 0});
 
 		m_squawkAlt = std::make_unique<SquawkAlt[]>(Size);
-		std::fill(m_squawkAlt.get(), m_squawkAlt.get() + Size, SquawkAlt{0, 0, 0, 0});
+		std::fill(m_squawkAlt.get(), m_squawkAlt.get() + Size,
+			SquawkAlt{0, 0, 0, AltitudeUnset});
 
 		m_msgStatTable = std::make_unique<MsgStatEntry[]>(Size);
 		std::fill(m_msgStatTable.get(), m_msgStatTable.get() + Size, MsgStatEntry{0});
@@ -222,6 +225,11 @@ public:
 
 	bool checkAltitude(const Iterator& entry, int32_t newAlt, bool updateState = true) noexcept {
 		auto& state = m_squawkAlt[entry.key];
+		if (state.altitude_25ft == AltitudeUnset) {
+			if (updateState)
+				state.altitude_25ft = newAlt / 25;
+			return false;
+		}
 		if (!updateState && state.altitude_cnt == 0)
 			return false;
 
@@ -346,7 +354,7 @@ private:
 		entry.ttl = 0;
 		clearOccupiedBit(index);
 		m_msgStatTable[index].last_time = 0;
-		m_squawkAlt[index] = SquawkAlt{0, 0, 0, 0};
+		m_squawkAlt[index] = SquawkAlt{0, 0, 0, AltitudeUnset};
 	}
 
 	

--- a/include/SampleStream.hpp
+++ b/include/SampleStream.hpp
@@ -77,6 +77,79 @@ public:
         return getRSSI(28);
     }
 
+    /// Ratio of the weakest preamble pulse to the strongest inter-pulse gap
+    /// across the eight preamble slots, sampled just before the frame. A real
+    /// preamble scores well above 1; noise hovers around 0.5.
+    float preambleScore(size_t stream) const noexcept {
+        return preambleScoreAt(stream, 135);
+    }
+
+    float preambleScoreAt(size_t stream, size_t PreambleStart) const noexcept {
+        constexpr size_t Half = Sampler::NumStreams >> 1;
+        const auto offsetInBlock = size_t(m_demodPos - m_sampleRingBuffer.readPos());
+
+        float pulse = std::numeric_limits<float>::max();
+        float gap = 0.0f;
+
+        for (size_t slot = 0; slot < 8; ++slot) {
+            const size_t base = (PreambleStart - slot) * Sampler::NumStreams;
+            for (size_t h = 0; h < 2; ++h) {
+                const size_t off = base - stream - h * Half;
+                float sum = 0.0f;
+                for (size_t k = 0; k < Half; ++k)
+                    sum += m_sampleRingBuffer.lookBack(off - k, offsetInBlock);
+
+                const bool isPulse = (h == 0 && (slot == 0 || slot == 1))
+                                  || (h == 1 && (slot == 3 || slot == 4));
+                if (isPulse)
+                    pulse = std::min(pulse, sum);
+                else
+                    gap = std::max(gap, sum);
+            }
+        }
+
+        return (gap > 0.0f) ? (pulse / gap) : 0.0f;
+    }
+
+    /// Signal-to-noise ratio of a frame: the peak magnitude across the frame's
+    /// data region over the median magnitude of a quiet window before it. This
+    /// is a ratio, so it is independent of receiver gain. A real transmission
+    /// sits well above its local noise floor; a fabricated frame is at it.
+    float snr(size_t frameBit) const noexcept {
+        const auto offsetInBlock = size_t(m_demodPos - m_sampleRingBuffer.readPos());
+
+        int32_t peak = 0;
+        {
+            const size_t delay = (size_t(128) - frameBit) * Sampler::NumStreams;
+            for (size_t s = 0; s < Sampler::NumStreams; s++)
+                peak = std::max(peak, m_sampleRingBuffer.lookBack(delay - s, offsetInBlock));
+        }
+
+        // noise floor: a low percentile of magnitudes over a quiet window
+        // before the preamble. The low percentile ignores any other
+        // transmission that happens to fall in the window, so the estimate is
+        // the receiver's own noise level and the ratio transfers between sites.
+        constexpr size_t NoiseBits = 64;
+        constexpr size_t StartBit = 200;
+        std::array<int32_t, NoiseBits * Sampler::NumStreams> window{};
+        size_t n = 0;
+        for (size_t b = 0; b < NoiseBits; b++) {
+            const size_t delay = (size_t(StartBit) + b) * Sampler::NumStreams;
+            for (size_t s = 0; s < Sampler::NumStreams; s++) {
+                window[n++] = m_sampleRingBuffer.lookBack(delay - s, offsetInBlock);
+                if (n == window.size())
+                    break;
+            }
+            if (n == window.size())
+                break;
+        }
+        std::sort(window.begin(), window.begin() + n);
+        const float noise = float(window[n / 4]);
+        if (noise <= 0.0f)
+            return 0.0f;
+        return float(peak) / noise;
+    }
+
 private:
     // Samples reach the ring as ((I*I) >> 2) + ((Q*Q) >> 2) with I and Q in
     // Q14, so the stored value is the squared magnitude times (SampleOne/2)^2
@@ -101,6 +174,14 @@ inline void SampleStream<Sampler>::read(InputReaderType& inputReader, Handler& m
     demodCore.setConfidenceSource(this, [](const void* ctx, uint8_t bit, size_t stream) -> float {
         return static_cast<const SampleStream<Sampler>*>(ctx)->confidenceAt(bit, stream);
     });
+    const auto preambleSource = [](const void* ctx, size_t stream) -> float {
+        return static_cast<const SampleStream<Sampler>*>(ctx)->preambleScore(stream);
+    };
+    demodCore.setPreambleSource(this, preambleSource);
+    const auto snrSource = [](const void* ctx, uint8_t frameBit) -> float {
+        return static_cast<const SampleStream<Sampler>*>(ctx)->snr(frameBit);
+    };
+    demodCore.setSnrSource(this, snrSource);
 
      // the main loop for reading the stream
     while (!inputReader.eof()) {

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -152,6 +152,15 @@ bool validationOnlyAltitudeCannotPoisonState() {
     return table.checkAltitude(entry, 10000);
 }
 
+bool firstLowAltitudeNeedsConfirmation() {
+    ICAOTable table;
+    const auto entry = table.insertWithCA(0x5abcde1);
+
+    if (table.checkAltitude(entry, -500))
+        return false;
+    return table.checkAltitude(entry, -500);
+}
+
 } // namespace
 
 int main() {
@@ -164,5 +173,6 @@ int main() {
         && emptySlotsRejectUnknownAddresses()
         && insertedAndReplacementEntriesAreFound()
         && expiredEntriesDisappear()
-        && validationOnlyAltitudeCannotPoisonState());
+        && validationOnlyAltitudeCannotPoisonState()
+        && firstLowAltitudeNeedsConfirmation());
 }


### PR DESCRIPTION
## Summary

Address-parity frames (DF0/4/5/16/20/21) recover the aircraft address from
their parity, so their CRC does not independently validate the message. This PR
closes two noise paths found while tracing an apparent aircraft with address
`4B20BC`:

1. A newly cached address no longer accepts its first low-altitude reply merely
   because the cache initialized altitude to zero. The first observation now
   initializes an explicit unset state and a second consistent reply confirms it.
2. Address-parity candidates are rejected when they are both at the local noise
   floor and have no Mode S preamble. The same gate prevents a random
   CRC-zero DF11 from licensing a fabricated address.

The RF tests are ratios rather than fixed RSSI thresholds, so they transfer
between receivers with different gain. They use samples already retained for
confidence calculation and run only after a candidate has matched a cached
address. No additional per-aircraft storage is required.

## False-positive trace

A noise window first produced a formally CRC-clean DF17:

    8B4B20BCADD674C230732C1024F0

This inserted `4B20BC` into the trusted ICAO cache. 4.46 seconds later, another
noise window produced a DF20 whose address-parity syndrome matched that entry:

    A6BD2034AD898E2D4BB13C914449

Its altitude decoded as `-500 ft`. Because the cache entry's initial altitude
was implicitly `0 ft`, the existing check accepted it:

    abs(0 - (-500)) = 500 ft <= 2,000 ft

The DF20 was consequently emitted. Inspection of the IQ samples showed no Mode S
burst at either event.

## Changes

- Represent an uninitialized altitude explicitly.
- Make the first altitude observation initialize state without validating it.
- Restore the sentinel whenever a cache entry is reset.
- Add a regression test using the observed `-500 ft` case.
- Measure candidate-frame SNR against a low percentile of the preceding quiet
  window.
- Score the four Mode S preamble pulses against the inter-pulse gaps.
- Gate DF0/4/5/16/20/21 and CRC-zero DF11 only when both RF checks fail.

Validation-only checks still leave uninitialized state unchanged. DF17/18
frames with a checkable CRC are not gated.

The gate is enabled by default. `STREAM1090_MIN_SNR` (default `2.5`) and
`STREAM1090_PREAMBLE_THRESHOLD` (default `1.2`) tune it;
`STREAM1090_PREAMBLE_GATE` enables or disables it.

## Verification

The altitude-confirmation regression tests pass. Replay results across four
60-second captures were:

| Capture | Before | After |
|---|---:|---:|
| RTL before PGA, 2.4 Msps | 2245 | 2245 |
| RTL after PGA, 2.4 Msps | 1917 | 1917 |
| RTL before PGA, 2.56 Msps | 2207 | 2207 |
| RTL after PGA, 2.56 Msps | 1707 | 1706 |

The only output removed by that change was the traced false positive:

    A6BD2034AD898E2D4BB13C914449

For the RF gate:

- Synthetic captures: removed the F-prefixed fabricated frame and other weak
  address-parity noise. DF17 collateral was zero on most captures and
  0.03-0.08% on three; net accepted traffic was essentially unchanged.
- Real 10 Msps captures: four recordings, using 400 MB windows, removed 0-3
  messages each, all DF0/16/20 and no DF17. Every removed frame had a
  noise-level preamble score (0.28-1.16 versus the 1.2 threshold); high-SNR
  exceptions were false preamble alignments inside another transmission, not
  standalone replies.
