### PR TITLE
CMake: factor unit test targets into a helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,51 +149,24 @@ target_compile_definitions(stream1090 PRIVATE
 target_link_libraries(stream1090 PRIVATE ${DEVICE_LIBS})
 
 include(CTest)
+
+function(stream1090_add_test target source)
+    add_executable(${target} ${source})
+    target_include_directories(${target} PRIVATE include)
+    target_compile_options(${target} PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    add_test(NAME ${target} COMMAND ${target})
+endfunction()
+
 if(BUILD_TESTING)
-    add_executable(crc_error_table_test tests/CRCErrorTableTest.cpp)
-    target_include_directories(crc_error_table_test PRIVATE include)
-    target_compile_options(crc_error_table_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME crc_error_table_test COMMAND crc_error_table_test)
-
-    add_executable(icao_cache_test tests/ICAOCacheTest.cpp)
-    target_include_directories(icao_cache_test PRIVATE include)
-    target_compile_options(icao_cache_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME icao_cache_test COMMAND icao_cache_test)
-
-    add_executable(df11_interrogator_test tests/DF11InterrogatorTest.cpp)
-    target_include_directories(df11_interrogator_test PRIVATE include)
-    target_compile_options(df11_interrogator_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME df11_interrogator_test COMMAND df11_interrogator_test)
-
-    add_executable(ring_buffer_test tests/RingBufferTest.cpp)
-    target_include_directories(ring_buffer_test PRIVATE include)
-    target_compile_options(ring_buffer_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME ring_buffer_test COMMAND ring_buffer_test)
-
-    add_executable(erasure_repair_test tests/ErasureRepairTest.cpp)
-    target_include_directories(erasure_repair_test PRIVATE include)
-    target_compile_options(erasure_repair_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME erasure_repair_test COMMAND erasure_repair_test)
-
-    add_executable(low_pass_filter_test tests/LowPassFilterTest.cpp)
-    target_include_directories(low_pass_filter_test PRIVATE include)
-    target_compile_options(low_pass_filter_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME low_pass_filter_test COMMAND low_pass_filter_test)
-
-    add_executable(sampler_test tests/SamplerTest.cpp)
-    target_include_directories(sampler_test PRIVATE include)
-    target_compile_options(sampler_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME sampler_test COMMAND sampler_test)
-
-    add_executable(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
-    target_include_directories(mode_s_altitude_test PRIVATE include)
-    target_compile_options(mode_s_altitude_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME mode_s_altitude_test COMMAND mode_s_altitude_test)
-
-    add_executable(mode_s_position_test tests/ModeSPositionTest.cpp)
-    target_include_directories(mode_s_position_test PRIVATE include)
-    target_compile_options(mode_s_position_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-    add_test(NAME mode_s_position_test COMMAND mode_s_position_test)
+    stream1090_add_test(crc_error_table_test tests/CRCErrorTableTest.cpp)
+    stream1090_add_test(icao_cache_test tests/ICAOCacheTest.cpp)
+    stream1090_add_test(df11_interrogator_test tests/DF11InterrogatorTest.cpp)
+    stream1090_add_test(ring_buffer_test tests/RingBufferTest.cpp)
+    stream1090_add_test(erasure_repair_test tests/ErasureRepairTest.cpp)
+    stream1090_add_test(low_pass_filter_test tests/LowPassFilterTest.cpp)
+    stream1090_add_test(sampler_test tests/SamplerTest.cpp)
+    stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
+    stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ We are ready to compile. Switch to the stream1090 folder and do the usual cmake 
 
 Run ```./stream1090 -h``` in the build directory to bring up the help screen. Verify that the second line starting with ```Native device support``` has your device type listed (```Airspy``` and/or ```RTL-SDR```). 
 
+To build and run the unit tests, enable `BUILD_TESTING` during configuration:
+
+```
+cmake -S . -B build -DBUILD_TESTING=ON
+cmake --build build
+ctest --test-dir build
+```
+
 ## First Steps
 Before we start, you have to understand how stream1090 works. The rough principle is:
 ```


### PR DESCRIPTION
## Summary

- factor the repeated unit-test target setup into `stream1090_add_test`
- keep each test declaration explicit while reducing it to one line
- document how to configure, build, and run the unit tests

## Why

Each unit test repeated the same executable, include-directory, compiler-option, and CTest registration commands. Centralizing those shared settings makes new tests easier to add and keeps their configuration consistent.

## Impact

There is no runtime behavior change. Existing test target names, sources, compile options, include paths, and CTest registrations remain unchanged.

## Validation

- `git diff --check`
- configured with `cmake -S . -B <temp-dir> -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release`
- built all targets successfully
- `ctest --test-dir <temp-dir> --output-on-failure`: 8/8 tests passed
