### PR TITLE
ICAOCache: refresh CA without discarding aircraft state

### DIFF
--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -93,6 +93,13 @@ public:
 
 	Iterator insertWithCA(uint32_t icaoWithCA) noexcept  {
 		const auto key = icaoWithCA & HashMask;
+		const auto previous = m_table[key].icao;
+		if (previous != 0 && (previous & 0xffffffu) == (icaoWithCA & 0xffffffu)) {
+			// CA is a per-frame capability field, not part of the aircraft's
+			// identity. Refresh it without discarding the trusted aircraft state.
+			m_table[key].icao = icaoWithCA;
+			return Iterator(key);
+		}
 		doResetEntry(key);
 		m_table[key].icao = icaoWithCA;
 		if (icaoWithCA != 0x0)

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -161,6 +161,22 @@ bool firstLowAltitudeNeedsConfirmation() {
     return table.checkAltitude(entry, -500);
 }
 
+bool capabilityChangePreservesTrustedAircraft() {
+    ICAOTable table;
+    constexpr uint32_t ca5 = 0x5abcde1;
+    constexpr uint32_t ca7 = 0x7abcde1;
+
+    const auto original = table.insertWithCA(ca5);
+    table.markAsTrustedSeen(original);
+    const auto refreshed = table.insertWithCA(ca7);
+
+    return refreshed.key == original.key
+        && !table.findWithCA(ca5).isValid()
+        && table.findWithCA(ca7).isValid()
+        && table.find(ca5 & 0xffffffu).isValid()
+        && table.isTrusted(refreshed);
+}
+
 } // namespace
 
 int main() {
@@ -174,5 +190,6 @@ int main() {
         && insertedAndReplacementEntriesAreFound()
         && expiredEntriesDisappear()
         && validationOnlyAltitudeCannotPoisonState()
-        && firstLowAltitudeNeedsConfirmation());
+        && firstLowAltitudeNeedsConfirmation()
+        && capabilityChangePreservesTrustedAircraft());
 }


### PR DESCRIPTION
## Summary

A transponder's capability (CA) bits in the all-call address are a per-frame
field, not part of the aircraft's identity. `insertWithCA` treated them as a
key, so whenever the reported capability changed the slot was reset, dropping
the TTL, trust state, squawk and altitude state for an aircraft the receiver
already knew.

## Changes

- `ICAOCache.hpp`: `insertWithCA` now refreshes the CA field in-place when the
  slot already holds the same 24-bit ICAO, preserving all per-aircraft state.
  A genuinely new address still takes the old reset path.
- `tests/ICAOCacheTest.cpp`: `capabilityChangePreservesTrustedAircraft`
  verifies the slot index, trust and address lookups survive a CA change
  (CA 5 -> 7 and back).

## Notes

- Lookup unchanged: `findWithCA` matches the full address including CA, so a
  stale CA is never used to gate output.