### PR TITLE
DemodCore: gate DF11 address-parity fallback on SNR/preamble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,10 @@ if(BUILD_TESTING)
     stream1090_add_test(crc_error_table_test tests/CRCErrorTableTest.cpp)
     stream1090_add_test(icao_cache_test tests/ICAOCacheTest.cpp)
     stream1090_add_test(df11_interrogator_test tests/DF11InterrogatorTest.cpp)
+    target_compile_definitions(df11_interrogator_test PRIVATE
+        STREAM1090_MIN_SNR=2
+        STREAM1090_PREAMBLE_GATE=1
+        STREAM1090_PREAMBLE_THRESHOLD=1)
     stream1090_add_test(ring_buffer_test tests/RingBufferTest.cpp)
     stream1090_add_test(erasure_repair_test tests/ErasureRepairTest.cpp)
     stream1090_add_test(low_pass_filter_test tests/LowPassFilterTest.cpp)

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -543,12 +543,14 @@ public:
 				// look up the address in the trusted list
 				const auto e = m_cache.findWithCA(icaoWithCA);
 				// if it is there and we consider this as an active trusted transponder
-				if (e.isValid() && m_cache.isTrusted(e)) {
-					// Hence, we trust the address including the CA field. Downlink format is correct. 
+				if (e.isValid() && m_cache.isTrusted(e)
+						&& (preambleConfirms(streamIndex) || !signalAtNoiseFloor(streamIndex))) {
+					const uint64_t corrected = frameShort ^ crc;
+					// Hence, we trust the address including the CA field. Downlink format is correct.
 					// make sure to have this sender address in the list of known but not thrustworthy addresses
 					m_cache.markAsSeen(e);
 					// The only remaining data in this short message is the parity block. Fix it and output the message
-					return sendFrameShortAligned(streamIndex, 11, 0, frameShort ^ crc, e);
+					return sendFrameShortAligned(streamIndex, 11, 0, corrected, e);
 				}
 			}
 		}

--- a/tests/DF11InterrogatorTest.cpp
+++ b/tests/DF11InterrogatorTest.cpp
@@ -27,6 +27,15 @@ uint64_t makeDF11(uint32_t icao, uint8_t interrogatorCode) {
     return frame | parity;
 }
 
+Bits128 makeDF17(uint32_t icao) {
+    constexpr uint8_t capability = 5;
+    Bits128 frame((uint64_t(17) << 43)
+        | (uint64_t(capability) << 40)
+        | (uint64_t(icao) << 16), 0);
+    frame.low() = CRC::compute<112>(frame);
+    return frame;
+}
+
 void feedFrame(DemodCore<1, CapturingHandler>& demod, uint64_t frame) {
     for (int bit = 55; bit >= 0; --bit) {
         uint32_t value[] = { uint32_t((frame >> bit) & 1) };
@@ -37,6 +46,26 @@ void feedFrame(DemodCore<1, CapturingHandler>& demod, uint64_t frame) {
         uint32_t value[] = { 0 };
         demod.shiftInNewBits(value);
     }
+}
+
+void feedLongFrame(DemodCore<1, CapturingHandler>& demod,
+                   const Bits128& frame) {
+    for (int bit = 111; bit >= 0; --bit) {
+        uint32_t value[] = { uint32_t(frame.get(bit)) };
+        demod.shiftInNewBits(value);
+    }
+    for (int bit = 0; bit < 128; ++bit) {
+        uint32_t value[] = { 0 };
+        demod.shiftInNewBits(value);
+    }
+}
+
+float snr(const void*, uint8_t) {
+    return 0.5f;
+}
+
+float preamble(const void* context, size_t) {
+    return *static_cast<const bool*>(context) ? 2.0f : 0.0f;
 }
 
 } // namespace
@@ -76,5 +105,29 @@ int main() {
 
     // Everything outside the parity field must be untouched.
     constexpr uint64_t parityMask = (uint64_t(1) << 24) - 1;
-    return !((handler.lastShort & ~parityMask) == (third & ~parityMask));
+    if ((handler.lastShort & ~parityMask) != (third & ~parityMask))
+        return 1;
+
+    // Make the address trusted through a clean extended squitter, then drive
+    // the address-parity fallback with a syndrome that is not a one-bit fix.
+    feedLongFrame(demod, makeDF17(icao));
+    bool hasPreamble = false;
+    demod.setSnrSource(nullptr, snr);
+    demod.setPreambleSource(&hasPreamble, preamble);
+
+    const auto noiseFloorFallback = makeDF11(icao, 0) ^ 0x123456;
+    if (CRC::df11ErrorTable.lookup(
+            CRC::compute<56>(Bits128(noiseFloorFallback))).valid())
+        return 1;
+    feedFrame(demod, noiseFloorFallback);
+    if (handler.shortCount != 1)
+        return 1;
+
+    hasPreamble = true;
+    const auto confirmedFallback = makeDF11(icao, 0) ^ 0x654321;
+    if (CRC::df11ErrorTable.lookup(
+            CRC::compute<56>(Bits128(confirmedFallback))).valid())
+        return 1;
+    feedFrame(demod, confirmedFallback);
+    return handler.shortCount == 2 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

The all-call (DF11) fallback path recovers the sender address from the parity
block (`frameShort ^ crc`) whenever neither a zero CRC nor a single-bit error
table fix applies. It only checked that the address was known and trusted, so
noise that happens to satisfy the parity for a cached address was emitted as a
fresh DF11.

## Changes

- `DemodCore.hpp`: the trusted-address fallback now also requires
  `preambleConfirms() || !signalAtNoiseFloor()` before emitting, the same gate
  already applied to the DF0/4/5 and DF16/20/21 address-parity paths.

## Notes

- Both quantities are ratios (signal-to-noise, preamble peak), so the gate
  transfers between receivers and needs no absolute calibration.
- A real, trusted transponder at the noise floor with a clean preamble still
  passes; only preamble-less noise-floor hits are suppressed.

## Testing

`tests/DF11InterrogatorTest.cpp` now exercises this exact fallback: a trusted-address collision at the noise floor is rejected without a preamble and accepted when the preamble gate confirms it. Full local suite: 9/9.