### PR TITLE
DemodCore: accept repaired positions only near a clean-pair position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(BUILD_TESTING)
     stream1090_add_test(sampler_test tests/SamplerTest.cpp)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
+    stream1090_add_test(position_repair_test tests/PositionRepairTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -294,11 +294,14 @@ public:
 			
 			// if we know this plane
 			if (e.isValid()) {
+				noteCleanPosition(e, frame, m_currTime);
 				m_cache.markAsTrustedSeen(e);
 				// and send the 112 bit message to the output
 				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 			} else {
-				m_cache.markAsTrustedSeen(m_cache.insertWithCA(icaoWithCA));
+				const auto inserted = m_cache.insertWithCA(icaoWithCA);
+				m_cache.markAsTrustedSeen(inserted);
+				noteCleanPosition(inserted, frame, m_currTime);
 			} 
 		} else {
 			// the crc is not zero, so we might have a broken message
@@ -321,7 +324,7 @@ public:
 				if (!e.isValid())
 					return false;
 
-				if (m_cache.isTrusted(e)) {
+				if (m_cache.isTrusted(e) && repairPositionPlausible(e, toRepair)) {
 					// log that fixing the message was a success
 					logStats(Stats::DF17_REPAIR_SUCCESS);
 					// and keep the trusted entry alive
@@ -400,6 +403,8 @@ public:
 		const auto icaoWithCA = ModeS::extractICAOWithCA_Long(repaired);
 		const auto e = m_cache.findWithCA(icaoWithCA);
 		if (!e.isValid() || !m_cache.isTrusted(e))
+			return false;
+		if (!repairPositionPlausible(e, repaired))
 			return false;
 
 		logStats(Stats::DF17_REPAIR_SUCCESS);
@@ -557,6 +562,80 @@ public:
 
 
 private:
+	static constexpr uint64_t CprPairWindowTicks { 10'000'000ull * NumStreams };
+	static constexpr uint64_t PositionMaxAgeTicks { 60'000'000ull * NumStreams };
+	static constexpr double RepairDistanceLimitKm { 100.0 };
+
+	static bool isAirbornePosition(uint8_t typeCode) noexcept {
+		return (typeCode >= 9 && typeCode <= 18)
+			|| (typeCode >= 20 && typeCode <= 22);
+	}
+
+	void noteCleanPosition(const ICAOTable::Iterator& entry, const Bits128& frame,
+			uint64_t sampleTime) noexcept {
+		if (!isAirbornePosition(ModeS::extractMEType(frame)))
+			return;
+		m_cache.noteCprClean(entry,
+			ModeS::extractAirbornePositionCprOdd(frame),
+			ModeS::extractAirbornePositionCprLat(frame),
+			ModeS::extractAirbornePositionCprLon(frame), sampleTime,
+			CprPairWindowTicks);
+	}
+
+	static void decodeCprRelative(double refLat, double refLon, bool odd,
+			uint32_t latCpr, uint32_t lonCpr, double& lat, double& lon) noexcept {
+		const double dlat = odd ? 360.0 / 59.0 : 360.0 / 60.0;
+		const double normalizedLat = double(latCpr) / 131072.0;
+		lat = dlat * (std::floor(refLat / dlat)
+			+ std::floor(0.5 + std::fmod(refLat, dlat) / dlat - normalizedLat)
+			+ normalizedLat);
+		if (lat > 90.0) lat -= 180.0;
+		if (lat < -90.0) lat += 180.0;
+
+		const int zones = ModeS::cprNl(lat) - (odd ? 1 : 0);
+		const int ni = zones > 1 ? zones : 1;
+		const double dlon = 360.0 / double(ni);
+		const double normalizedLon = double(lonCpr) / 131072.0;
+		lon = dlon * (std::floor(refLon / dlon)
+			+ std::floor(0.5 + std::fmod(refLon, dlon) / dlon - normalizedLon)
+			+ normalizedLon);
+		if (lon > 180.0) lon -= 360.0;
+		if (lon < -180.0) lon += 360.0;
+	}
+
+	static double distanceKm(double lat1, double lon1, double lat2, double lon2) noexcept {
+		constexpr double EarthRadiusKm = 6371.0;
+		constexpr double DegreesToRadians = 3.14159265358979323846 / 180.0;
+		const double deltaLat = (lat2 - lat1) * DegreesToRadians;
+		const double deltaLon = (lon2 - lon1) * DegreesToRadians;
+		const double a = std::sin(deltaLat * 0.5) * std::sin(deltaLat * 0.5)
+			+ std::cos(lat1 * DegreesToRadians) * std::cos(lat2 * DegreesToRadians)
+			* std::sin(deltaLon * 0.5) * std::sin(deltaLon * 0.5);
+		return 2.0 * EarthRadiusKm * std::asin(std::sqrt(a));
+	}
+
+	bool repairPositionPlausible(const ICAOTable::Iterator& entry,
+			const Bits128& frame) const noexcept {
+		if (!isAirbornePosition(ModeS::extractMEType(frame)))
+			return true;
+
+		int32_t refLatE5 = 0;
+		int32_t refLonE5 = 0;
+		if (!m_cache.cachedPosition(entry, refLatE5, refLonE5,
+				m_currTime, PositionMaxAgeTicks))
+			return false;
+
+		const double refLat = refLatE5 * 1e-5;
+		const double refLon = refLonE5 * 1e-5;
+		double lat = 0.0;
+		double lon = 0.0;
+		decodeCprRelative(refLat, refLon,
+			ModeS::extractAirbornePositionCprOdd(frame),
+			ModeS::extractAirbornePositionCprLat(frame),
+			ModeS::extractAirbornePositionCprLon(frame), lat, lon);
+		return distanceKm(refLat, refLon, lat, lon) <= RepairDistanceLimitKm;
+	}
+
 	const void* m_confidenceCtx = nullptr;
 	ConfidenceFn m_confidenceFn = nullptr;
 	const void* m_preambleCtx = nullptr;

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -12,6 +12,8 @@
 #include <limits>
 #include <memory>
 
+#include "ModeS.hpp"
+
 class ICAOTable {
 public:
 	static constexpr auto TTL_not_trusted { 10 };
@@ -60,6 +62,16 @@ public:
 		// the last altitude in feet received
 		uint8_t altitude_cnt;
 		int16_t altitude_25ft;
+
+		uint32_t cpr_even_lat;
+		uint32_t cpr_even_lon;
+		uint32_t cpr_odd_lat;
+		uint32_t cpr_odd_lon;
+		uint64_t cpr_even_time;
+		uint64_t cpr_odd_time;
+		int32_t last_lat_e5;
+		int32_t last_lon_e5;
+		uint64_t position_time;
 	};
 
     // simple struct keeping an index
@@ -85,7 +97,7 @@ public:
 
 		m_squawkAlt = std::make_unique<SquawkAlt[]>(Size);
 		std::fill(m_squawkAlt.get(), m_squawkAlt.get() + Size,
-			SquawkAlt{0, 0, 0, AltitudeUnset});
+			SquawkAlt{0, 0, 0, AltitudeUnset, 0, 0, 0, 0, 0, 0, 0, 0, 0});
 
 		m_msgStatTable = std::make_unique<MsgStatEntry[]>(Size);
 		std::fill(m_msgStatTable.get(), m_msgStatTable.get() + Size, MsgStatEntry{0});
@@ -260,6 +272,46 @@ public:
 		return false;
 	}
 
+	// Seed the per-aircraft CPR pair from a CRC-clean airborne position frame.
+	// When an odd/even pair within fitWindow lands close in time, the decoded
+	// position becomes the reference the repair gate checks against.
+	void noteCprClean(const Iterator& entry, bool odd, uint32_t latCpr,
+			uint32_t lonCpr, uint64_t now, uint64_t pairWindow) noexcept {
+		auto& state = m_squawkAlt[entry.key];
+		if (odd) {
+			state.cpr_odd_lat = latCpr;
+			state.cpr_odd_lon = lonCpr;
+			state.cpr_odd_time = now;
+		} else {
+			state.cpr_even_lat = latCpr;
+			state.cpr_even_lon = lonCpr;
+			state.cpr_even_time = now;
+		}
+
+		const uint64_t otherTime = odd ? state.cpr_even_time : state.cpr_odd_time;
+		if (otherTime == 0 || now - otherTime > pairWindow)
+			return;
+
+		double lat = 0.0;
+		double lon = 0.0;
+		if (!ModeS::decodeCprGlobal(state.cpr_even_lat, state.cpr_even_lon,
+				state.cpr_odd_lat, state.cpr_odd_lon, lat, lon))
+			return;
+		state.last_lat_e5 = int32_t(lat * 1e5);
+		state.last_lon_e5 = int32_t(lon * 1e5);
+		state.position_time = now;
+	}
+
+	bool cachedPosition(const Iterator& entry, int32_t& latE5, int32_t& lonE5,
+			uint64_t now, uint64_t maxAge) const noexcept {
+		const auto& state = m_squawkAlt[entry.key];
+		if (state.position_time == 0 || now - state.position_time > maxAge)
+			return false;
+		latE5 = state.last_lat_e5;
+		lonE5 = state.last_lon_e5;
+		return true;
+	}
+
 	MsgStatEntry& getMsgStatEntry(const Iterator& it) noexcept {
 		return m_msgStatTable[it.key];
 	}
@@ -361,7 +413,7 @@ private:
 		entry.ttl = 0;
 		clearOccupiedBit(index);
 		m_msgStatTable[index].last_time = 0;
-		m_squawkAlt[index] = SquawkAlt{0, 0, 0, AltitudeUnset};
+		m_squawkAlt[index] = SquawkAlt{0, 0, 0, AltitudeUnset, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	}
 
 	

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -2,6 +2,8 @@
 
 #include "ICAOCache.hpp"
 
+#include <cmath>
+
 namespace {
 
 void tick(ICAOTable& table, uint32_t count) {
@@ -177,6 +179,24 @@ bool capabilityChangePreservesTrustedAircraft() {
         && table.isTrusted(refreshed);
 }
 
+bool cleanCprPairSeedsPosition() {
+    ICAOTable table;
+    const auto entry = table.insertWithCA(0x5abcde1);
+    constexpr uint64_t now = 1'000;
+
+    table.noteCprClean(entry, false, 93000, 51372, now, 10'000);
+    int32_t lat = 0;
+    int32_t lon = 0;
+    if (table.cachedPosition(entry, lat, lon, now, 60'000))
+        return false;
+
+    table.noteCprClean(entry, true, 74158, 50194, now + 100, 10'000);
+    return table.cachedPosition(entry, lat, lon, now + 100, 60'000)
+        && std::abs(lat - 5'225'720) < 100
+        && std::abs(lon - 391'937) < 100
+        && !table.cachedPosition(entry, lat, lon, now + 60'101, 60'000);
+}
+
 } // namespace
 
 int main() {
@@ -191,5 +211,6 @@ int main() {
         && expiredEntriesDisappear()
         && validationOnlyAltitudeCannotPoisonState()
         && firstLowAltitudeNeedsConfirmation()
-        && capabilityChangePreservesTrustedAircraft());
+        && capabilityChangePreservesTrustedAircraft()
+        && cleanCprPairSeedsPosition());
 }

--- a/tests/PositionRepairTest.cpp
+++ b/tests/PositionRepairTest.cpp
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "DemodCore.hpp"
+
+#include <array>
+#include <cstdint>
+
+namespace {
+
+struct CapturingHandler {
+	void handleShort(uint64_t, uint64_t) {}
+
+	void handleLong(uint64_t, const Bits128& frame) {
+		if (longCount < frames.size())
+			frames[longCount] = frame;
+		++longCount;
+	}
+
+	uint32_t longCount { 0 };
+	std::array<Bits128, 8> frames { Bits128(), Bits128(), Bits128(),
+		Bits128(), Bits128(), Bits128(), Bits128(), Bits128() };
+};
+
+Bits128 makePosition(uint32_t icao, bool odd, uint32_t latCpr,
+		uint32_t lonCpr, uint8_t capability = 5) {
+	const uint64_t high = (uint64_t(17) << 43)
+		| (uint64_t(capability) << 40)
+		| (uint64_t(icao) << 16)
+		| (uint64_t(11) << 11);
+	const uint64_t low = (uint64_t(odd) << 58)
+		| (uint64_t(latCpr) << 41)
+		| (uint64_t(lonCpr) << 24);
+	Bits128 frame(high, low);
+	frame.low() |= CRC::compute<112>(frame);
+	return frame;
+}
+
+Bits128 makeIdentity(uint32_t icao, uint8_t capability = 5) {
+	const uint64_t high = (uint64_t(17) << 43)
+		| (uint64_t(capability) << 40)
+		| (uint64_t(icao) << 16)
+		| (uint64_t(5) << 11);
+	Bits128 frame(high, 0);
+	frame.low() = CRC::compute<112>(frame);
+	return frame;
+}
+
+void feedSilence(DemodCore<1, CapturingHandler>& demod, uint32_t bits) {
+	for (uint32_t bit = 0; bit < bits; ++bit) {
+		uint32_t value[] = { 0 };
+		demod.shiftInNewBits(value);
+	}
+}
+
+void feedFrame(DemodCore<1, CapturingHandler>& demod, const Bits128& frame) {
+	for (int bit = 111; bit >= 0; --bit) {
+		uint32_t value[] = { uint32_t(frame.get(bit)) };
+		demod.shiftInNewBits(value);
+	}
+	feedSilence(demod, 16);
+}
+
+} // namespace
+
+int main() {
+	CapturingHandler handler;
+	DemodCore<1, CapturingHandler> demod(handler);
+
+	// A repaired position for a trusted aircraft with no clean odd/even pair
+	// behind it must be rejected (repairs never establish the first position).
+	// 0x12345 becomes trusted via a clean identity frame first.
+	feedFrame(demod, makeIdentity(0x123456));
+	feedSilence(demod, 128);
+	auto firstRepair = makePosition(0x123456, false, 93000, 51372);
+	firstRepair.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, firstRepair);
+	if (handler.longCount != 0)
+		return 1;
+
+	// A CRC-clean even/odd pair establishes the reference position; both
+	// frames are emitted.
+	const auto firstEven = makePosition(0x123456, false, 93000, 51372);
+	feedFrame(demod, firstEven);
+	feedSilence(demod, 128);
+	const auto firstOdd = makePosition(0x123456, true, 74158, 50194);
+	feedFrame(demod, firstOdd);
+	if (handler.longCount != 2)
+		return 2;
+
+	// A single-bit damage repair landing near the established position passes.
+	auto nearby = makePosition(0x123456, false, 93000, 51372);
+	nearby.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, nearby);
+	if (handler.longCount != 3)
+		return 3;
+
+	// A repair that would place the aircraft > 100 km away is rejected.
+	auto farAway = makePosition(0x123456, false, 0, 0);
+	farAway.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, farAway);
+
+	return handler.longCount != 3 ? 4 : 0;
+}


### PR DESCRIPTION
## Summary

A repaired DF17/18/19 frame whose CRC was reconstructed from a damaged one is
trusted only when its address belongs to a trusted aircraft. The content is
then accepted blindly, so a coincidental address match plus a repaired CPR
payload can mint a position for an aircraft that never transmitted one.

This PR gates the two repair paths (error-table fix and erasure repair) on
plausibility: an airborne-position repair is emitted only if its CPR
coordinates land within 100 km of a position established by a recent,
CRC-clean odd/even pair. A repair can never establish the first position for
an aircraft.

## Changes
- `ICAOCache.hpp`: `SquawkAlt` gains the CPR state and a decoded position
  cache seeded only by CRC-clean airborne odd/even pairs
  (`noteCprClean`, `cachedPosition`, 10 s pair window, 60 s position TTL).
- `DemodCore.hpp`: `isAirbornePosition`, `noteCleanPosition`,
  `decodeCprRelative`, `distanceKm`, `repairPositionPlausible` (100 km);
  gates the two extended-squitter repair paths (error-table and erasure repair); seeds the CPR
  pair from CRC-clean frames only.
- Tests: `position_repair_test` (repair rejected without an established
  position, nearby repair accepted, > 100 km repair rejected) and
  `cleanCprPairSeedsPosition` in the ICAO cache tests.

## Notes
- Type codes 9-18 and 20-22 only; 19 (velocity) is untouched.
- A 100 km threshold covers the 60 s window with a wide margin.
- Depends on the CPR utilities in #48, and on #49 so a CA change does not
  wipe the CPR cache between the even and odd frame.