### PR TITLE
DemodCore: require a second sighting before trusting a new aircraft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(BUILD_TESTING)
     stream1090_add_test(sampler_test tests/SamplerTest.cpp)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
+    stream1090_add_test(position_repair_test tests/PositionRepairTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if(BUILD_TESTING)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
     stream1090_add_test(position_repair_test tests/PositionRepairTest.cpp)
+    stream1090_add_test(df17_first_frame_test tests/DF17FirstFrameTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -294,11 +294,14 @@ public:
 			
 			// if we know this plane
 			if (e.isValid()) {
+				noteCleanPosition(e, frame, m_currTime);
 				m_cache.markAsTrustedSeen(e);
 				// and send the 112 bit message to the output
 				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 			} else {
-				m_cache.markAsTrustedSeen(m_cache.insertWithCA(icaoWithCA));
+				const auto inserted = m_cache.insertWithCA(icaoWithCA);
+				m_cache.markAsTrustedSeen(inserted);
+				noteCleanPosition(inserted, frame, m_currTime);
 			} 
 		} else {
 			// the crc is not zero, so we might have a broken message
@@ -321,7 +324,7 @@ public:
 				if (!e.isValid())
 					return false;
 
-				if (m_cache.isTrusted(e)) {
+				if (m_cache.isTrusted(e) && repairPositionPlausible(e, toRepair)) {
 					// log that fixing the message was a success
 					logStats(Stats::DF17_REPAIR_SUCCESS);
 					// and keep the trusted entry alive
@@ -400,6 +403,8 @@ public:
 		const auto icaoWithCA = ModeS::extractICAOWithCA_Long(repaired);
 		const auto e = m_cache.findWithCA(icaoWithCA);
 		if (!e.isValid() || !m_cache.isTrusted(e))
+			return false;
+		if (!repairPositionPlausible(e, repaired))
 			return false;
 
 		logStats(Stats::DF17_REPAIR_SUCCESS);
@@ -557,6 +562,80 @@ public:
 
 
 private:
+	static constexpr uint64_t CprPairWindowTicks { 10'000'000ull * NumStreams };
+	static constexpr uint64_t PositionMaxAgeTicks { 60'000'000ull * NumStreams };
+	static constexpr double RepairDistanceLimitKm { 100.0 };
+
+	static bool isAirbornePosition(uint8_t typeCode) noexcept {
+		return (typeCode >= 9 && typeCode <= 18)
+			|| (typeCode >= 20 && typeCode <= 22);
+	}
+
+	void noteCleanPosition(const ICAOTable::Iterator& entry, const Bits128& frame,
+			uint64_t sampleTime) noexcept {
+		if (!isAirbornePosition(ModeS::extractMEType(frame)))
+			return;
+		m_cache.noteCprClean(entry,
+			ModeS::extractAirbornePositionCprOdd(frame),
+			ModeS::extractAirbornePositionCprLat(frame),
+			ModeS::extractAirbornePositionCprLon(frame), sampleTime,
+			CprPairWindowTicks);
+	}
+
+	static void decodeCprRelative(double refLat, double refLon, bool odd,
+			uint32_t latCpr, uint32_t lonCpr, double& lat, double& lon) noexcept {
+		const double dlat = odd ? 360.0 / 59.0 : 360.0 / 60.0;
+		const double normalizedLat = double(latCpr) / 131072.0;
+		lat = dlat * (std::floor(refLat / dlat)
+			+ std::floor(0.5 + std::fmod(refLat, dlat) / dlat - normalizedLat)
+			+ normalizedLat);
+		if (lat > 90.0) lat -= 180.0;
+		if (lat < -90.0) lat += 180.0;
+
+		const int zones = ModeS::cprNl(lat) - (odd ? 1 : 0);
+		const int ni = zones > 1 ? zones : 1;
+		const double dlon = 360.0 / double(ni);
+		const double normalizedLon = double(lonCpr) / 131072.0;
+		lon = dlon * (std::floor(refLon / dlon)
+			+ std::floor(0.5 + std::fmod(refLon, dlon) / dlon - normalizedLon)
+			+ normalizedLon);
+		if (lon > 180.0) lon -= 360.0;
+		if (lon < -180.0) lon += 360.0;
+	}
+
+	static double distanceKm(double lat1, double lon1, double lat2, double lon2) noexcept {
+		constexpr double EarthRadiusKm = 6371.0;
+		constexpr double DegreesToRadians = 3.14159265358979323846 / 180.0;
+		const double deltaLat = (lat2 - lat1) * DegreesToRadians;
+		const double deltaLon = (lon2 - lon1) * DegreesToRadians;
+		const double a = std::sin(deltaLat * 0.5) * std::sin(deltaLat * 0.5)
+			+ std::cos(lat1 * DegreesToRadians) * std::cos(lat2 * DegreesToRadians)
+			* std::sin(deltaLon * 0.5) * std::sin(deltaLon * 0.5);
+		return 2.0 * EarthRadiusKm * std::asin(std::sqrt(a));
+	}
+
+	bool repairPositionPlausible(const ICAOTable::Iterator& entry,
+			const Bits128& frame) const noexcept {
+		if (!isAirbornePosition(ModeS::extractMEType(frame)))
+			return true;
+
+		int32_t refLatE5 = 0;
+		int32_t refLonE5 = 0;
+		if (!m_cache.cachedPosition(entry, refLatE5, refLonE5,
+				m_currTime, PositionMaxAgeTicks))
+			return false;
+
+		const double refLat = refLatE5 * 1e-5;
+		const double refLon = refLonE5 * 1e-5;
+		double lat = 0.0;
+		double lon = 0.0;
+		decodeCprRelative(refLat, refLon,
+			ModeS::extractAirbornePositionCprOdd(frame),
+			ModeS::extractAirbornePositionCprLat(frame),
+			ModeS::extractAirbornePositionCprLon(frame), lat, lon);
+		return distanceKm(refLat, refLon, lat, lon) <= RepairDistanceLimitKm;
+	}
+
 	const void* m_confidenceCtx = nullptr;
 	ConfidenceFn m_confidenceFn = nullptr;
 	const void* m_preambleCtx = nullptr;

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -14,6 +14,7 @@
 #include "ModeS.hpp"
 #include "ICAOCache.hpp"
 #include "Stats.hpp"
+#include <array>
 #include <bit>
 #include <cmath>
 #include "ShiftRegisters.hpp"
@@ -119,7 +120,7 @@ public:
 							  const ICAOTable::Iterator& it) {
 		auto& e = m_cache.getMsgStatEntry(it);
 		static constexpr uint64_t DUP_WINDOW_TICKS = 30 * NumStreams;
-		if ((m_currTime - e.last_time) < DUP_WINDOW_TICKS) {
+		if (m_currTime - e.last_time < DUP_WINDOW_TICKS) {
 		    e.last_time = m_currTime;
     		logStatsDup(downlinkFormat);
     		return false;
@@ -290,19 +291,41 @@ public:
 			logStats(Stats::DF17_GOOD_MESSAGE);
 			// get the address including the CA field
 			const auto icaoWithCA = ModeS::extractICAOWithCA_Long(frame);
-			const auto e = m_cache.findWithCA(icaoWithCA);
-			
-			// if we know this plane
-			if (e.isValid()) {
-				noteCleanPosition(e, frame, m_currTime);
-				m_cache.markAsTrustedSeen(e);
-				// and send the 112 bit message to the output
-				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
-			} else {
-				const auto inserted = m_cache.insertWithCA(icaoWithCA);
-				m_cache.markAsTrustedSeen(inserted);
-				noteCleanPosition(inserted, frame, m_currTime);
-			} 
+			auto e = m_cache.findWithCA(icaoWithCA);
+			const auto icao = icaoWithCA & 0xffffffu;
+			auto& pending = pendingFirstFrame(icao);
+			const bool hasPending = pending.valid && pending.icao == icao;
+
+			if (!e.isValid()) {
+				if (m_cache.find(icao).isValid()) {
+					// Same aircraft as before, different reported CA: keep the
+					// cached trust and state.
+					e = m_cache.insertWithCA(icaoWithCA);
+				} else {
+					// First sighting of an unknown address: cache it
+					// untrusted and hold the frame for a second sighting.
+					e = m_cache.insertWithCA(icaoWithCA);
+					m_cache.markAsSeen(e);
+					pending = PendingFirstFrame{
+						icao, true, m_currTime, frame};
+					return false;
+				}
+			}
+
+			// A recorded first sighting is confirmed by this one.
+			if (hasPending) {
+				const auto age = m_currTime - pending.sampleTime;
+				if (age < FirstFrameConfirmationMinTicks)
+					return false;
+				if (age <= FirstFrameConfirmationMaxTicks)
+					noteCleanPosition(e, pending.frame, pending.sampleTime);
+				pending = PendingFirstFrame{};
+			}
+
+			noteCleanPosition(e, frame, m_currTime);
+			m_cache.markAsTrustedSeen(e);
+			// and send the 112 bit message to the output
+			return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 		} else {
 			// the crc is not zero, so we might have a broken message
 			logStats(Stats::DF17_BAD_MESSAGE);
@@ -636,6 +659,26 @@ private:
 		return distanceKm(refLat, refLon, lat, lon) <= RepairDistanceLimitKm;
 	}
 
+	// First sighting of an unknown address: cache it for corroboration and
+	// require a second, separate sighting before the aircraft is trusted. The
+	// held frame is never emitted later: doing so would put an old MLAT timestamp
+	// after newer output and would attach the confirming frame's RSSI to it.
+	struct PendingFirstFrame {
+		uint32_t icao { 0 };
+		bool valid { false };
+		uint64_t sampleTime { 0 };
+		Bits128 frame { uint64_t(0) };
+	};
+
+	static constexpr size_t FirstFramePendingCount { 1024 };
+	static constexpr uint64_t FirstFrameConfirmationMinTicks { 100 * NumStreams };
+	static constexpr uint64_t FirstFrameConfirmationMaxTicks { 2'000'000 * NumStreams };
+
+	PendingFirstFrame& pendingFirstFrame(uint32_t icao) noexcept {
+		const auto index = (icao * 0x9e3779b1u) >> (32 - 10);
+		return m_pendingFirstFrames[index];
+	}
+
 	const void* m_confidenceCtx = nullptr;
 	ConfidenceFn m_confidenceFn = nullptr;
 	const void* m_preambleCtx = nullptr;
@@ -681,6 +724,7 @@ private:
 
 	// plane lookup table
 	ICAOTable m_cache; 
+	std::array<PendingFirstFrame, FirstFramePendingCount> m_pendingFirstFrames{}; 
 	
 	// the current time measured in samples.
 	uint64_t m_currTime{ 0 };

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -12,6 +12,8 @@
 #include <limits>
 #include <memory>
 
+#include "ModeS.hpp"
+
 class ICAOTable {
 public:
 	static constexpr auto TTL_not_trusted { 10 };
@@ -60,6 +62,16 @@ public:
 		// the last altitude in feet received
 		uint8_t altitude_cnt;
 		int16_t altitude_25ft;
+
+		uint32_t cpr_even_lat;
+		uint32_t cpr_even_lon;
+		uint32_t cpr_odd_lat;
+		uint32_t cpr_odd_lon;
+		uint64_t cpr_even_time;
+		uint64_t cpr_odd_time;
+		int32_t last_lat_e5;
+		int32_t last_lon_e5;
+		uint64_t position_time;
 	};
 
     // simple struct keeping an index
@@ -85,7 +97,7 @@ public:
 
 		m_squawkAlt = std::make_unique<SquawkAlt[]>(Size);
 		std::fill(m_squawkAlt.get(), m_squawkAlt.get() + Size,
-			SquawkAlt{0, 0, 0, AltitudeUnset});
+			SquawkAlt{0, 0, 0, AltitudeUnset, 0, 0, 0, 0, 0, 0, 0, 0, 0});
 
 		m_msgStatTable = std::make_unique<MsgStatEntry[]>(Size);
 		std::fill(m_msgStatTable.get(), m_msgStatTable.get() + Size, MsgStatEntry{0});
@@ -260,6 +272,46 @@ public:
 		return false;
 	}
 
+	// Seed the per-aircraft CPR pair from a CRC-clean airborne position frame.
+	// When an odd/even pair within fitWindow lands close in time, the decoded
+	// position becomes the reference the repair gate checks against.
+	void noteCprClean(const Iterator& entry, bool odd, uint32_t latCpr,
+			uint32_t lonCpr, uint64_t now, uint64_t pairWindow) noexcept {
+		auto& state = m_squawkAlt[entry.key];
+		if (odd) {
+			state.cpr_odd_lat = latCpr;
+			state.cpr_odd_lon = lonCpr;
+			state.cpr_odd_time = now;
+		} else {
+			state.cpr_even_lat = latCpr;
+			state.cpr_even_lon = lonCpr;
+			state.cpr_even_time = now;
+		}
+
+		const uint64_t otherTime = odd ? state.cpr_even_time : state.cpr_odd_time;
+		if (otherTime == 0 || now - otherTime > pairWindow)
+			return;
+
+		double lat = 0.0;
+		double lon = 0.0;
+		if (!ModeS::decodeCprGlobal(state.cpr_even_lat, state.cpr_even_lon,
+				state.cpr_odd_lat, state.cpr_odd_lon, lat, lon))
+			return;
+		state.last_lat_e5 = int32_t(lat * 1e5);
+		state.last_lon_e5 = int32_t(lon * 1e5);
+		state.position_time = now;
+	}
+
+	bool cachedPosition(const Iterator& entry, int32_t& latE5, int32_t& lonE5,
+			uint64_t now, uint64_t maxAge) const noexcept {
+		const auto& state = m_squawkAlt[entry.key];
+		if (state.position_time == 0 || now - state.position_time > maxAge)
+			return false;
+		latE5 = state.last_lat_e5;
+		lonE5 = state.last_lon_e5;
+		return true;
+	}
+
 	MsgStatEntry& getMsgStatEntry(const Iterator& it) noexcept {
 		return m_msgStatTable[it.key];
 	}
@@ -361,7 +413,7 @@ private:
 		entry.ttl = 0;
 		clearOccupiedBit(index);
 		m_msgStatTable[index].last_time = 0;
-		m_squawkAlt[index] = SquawkAlt{0, 0, 0, AltitudeUnset};
+		m_squawkAlt[index] = SquawkAlt{0, 0, 0, AltitudeUnset, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	}
 
 	

--- a/tests/DF17FirstFrameTest.cpp
+++ b/tests/DF17FirstFrameTest.cpp
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "DemodCore.hpp"
+
+#include <array>
+#include <cstdint>
+
+namespace {
+
+struct CapturingHandler {
+	void handleShort(uint64_t, uint64_t) {}
+
+	void handleLong(uint64_t sampleTime, const Bits128& frame) {
+		if (longCount < frames.size()) {
+			sampleTimes[longCount] = sampleTime;
+			frames[longCount] = frame;
+		}
+		++longCount;
+	}
+
+	uint32_t longCount { 0 };
+	std::array<uint64_t, 2> sampleTimes{};
+	std::array<Bits128, 2> frames { Bits128(), Bits128() };
+};
+
+Bits128 makeDF17(uint32_t icao, uint8_t typeCode, uint8_t capability = 5) {
+	const uint64_t high = (uint64_t(17) << 43)
+		| (uint64_t(capability) << 40)
+		| (uint64_t(icao) << 16)
+		| (uint64_t(typeCode) << 11);
+	Bits128 frame(high, 0);
+	frame.low() = CRC::compute<112>(frame);
+	return frame;
+}
+
+void feedSilence(DemodCore<1, CapturingHandler>& demod, uint32_t bits) {
+	for (uint32_t bit = 0; bit < bits; ++bit) {
+		uint32_t value[] = { 0 };
+		demod.shiftInNewBits(value);
+	}
+}
+
+void feedFrame(DemodCore<1, CapturingHandler>& demod, const Bits128& frame) {
+	for (int bit = 111; bit >= 0; --bit) {
+		uint32_t value[] = { uint32_t(frame.get(bit)) };
+		demod.shiftInNewBits(value);
+	}
+	feedSilence(demod, 16);
+}
+
+} // namespace
+
+int main() {
+	// The first frame of an unknown aircraft is held: nothing is emitted even
+	// if a CRC-clean frame of a different aircraft and a repair candidate for
+	// the same address arrive in between.
+	const auto first = makeDF17(0xabcdef, 1);
+	const auto second = makeDF17(0xabcdef, 2, 7);
+	const auto unrelated = makeDF17(0x123456, 1);
+	const auto unrelatedSecond = makeDF17(0x123456, 2);
+	auto repairCandidate = makeDF17(0xabcdef, 3);
+	repairCandidate.flip(30);
+
+	CapturingHandler handler;
+	DemodCore<1, CapturingHandler> demod(handler);
+	feedFrame(demod, first);
+	feedSilence(demod, 128);
+	feedFrame(demod, unrelated);
+	feedSilence(demod, 128);
+	feedFrame(demod, unrelatedSecond);
+	feedSilence(demod, 128);
+	feedFrame(demod, repairCandidate);
+	if (!(handler.longCount == 1 && handler.frames[0] == unrelatedSecond))
+		return 1;
+
+	// A second CRC-clean sighting confirms the aircraft. Only the current frame
+	// is emitted: releasing the held frame here would put an old MLAT timestamp
+	// after the unrelated output above and would give it the current RSSI.
+	feedSilence(demod, 128);
+	feedFrame(demod, second);
+	if (!(handler.longCount == 2
+			&& handler.frames[0] == unrelatedSecond
+			&& handler.frames[1] == second
+			&& handler.sampleTimes[0] < handler.sampleTimes[1]))
+		return 2;
+
+	// If no confirmation arrives inside the window the held frame is dropped.
+	CapturingHandler expiredHandler;
+	DemodCore<1, CapturingHandler> expiredDemod(expiredHandler);
+	feedFrame(expiredDemod, first);
+	feedSilence(expiredDemod, 2'000'001);
+	feedFrame(expiredDemod, second);
+	if (!(expiredHandler.longCount == 1
+			&& expiredHandler.frames[0] == second))
+		return 3;
+
+	return 0;
+}

--- a/tests/ICAOCacheTest.cpp
+++ b/tests/ICAOCacheTest.cpp
@@ -2,6 +2,8 @@
 
 #include "ICAOCache.hpp"
 
+#include <cmath>
+
 namespace {
 
 void tick(ICAOTable& table, uint32_t count) {
@@ -177,6 +179,24 @@ bool capabilityChangePreservesTrustedAircraft() {
         && table.isTrusted(refreshed);
 }
 
+bool cleanCprPairSeedsPosition() {
+    ICAOTable table;
+    const auto entry = table.insertWithCA(0x5abcde1);
+    constexpr uint64_t now = 1'000;
+
+    table.noteCprClean(entry, false, 93000, 51372, now, 10'000);
+    int32_t lat = 0;
+    int32_t lon = 0;
+    if (table.cachedPosition(entry, lat, lon, now, 60'000))
+        return false;
+
+    table.noteCprClean(entry, true, 74158, 50194, now + 100, 10'000);
+    return table.cachedPosition(entry, lat, lon, now + 100, 60'000)
+        && std::abs(lat - 5'225'720) < 100
+        && std::abs(lon - 391'937) < 100
+        && !table.cachedPosition(entry, lat, lon, now + 60'101, 60'000);
+}
+
 } // namespace
 
 int main() {
@@ -191,5 +211,6 @@ int main() {
         && expiredEntriesDisappear()
         && validationOnlyAltitudeCannotPoisonState()
         && firstLowAltitudeNeedsConfirmation()
-        && capabilityChangePreservesTrustedAircraft());
+        && capabilityChangePreservesTrustedAircraft()
+        && cleanCprPairSeedsPosition());
 }

--- a/tests/PositionRepairTest.cpp
+++ b/tests/PositionRepairTest.cpp
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "DemodCore.hpp"
+
+#include <array>
+#include <cstdint>
+
+namespace {
+
+struct CapturingHandler {
+	void handleShort(uint64_t, uint64_t) {}
+
+	void handleLong(uint64_t, const Bits128& frame) {
+		if (longCount < frames.size())
+			frames[longCount] = frame;
+		++longCount;
+	}
+
+	uint32_t longCount { 0 };
+	std::array<Bits128, 8> frames { Bits128(), Bits128(), Bits128(),
+		Bits128(), Bits128(), Bits128(), Bits128(), Bits128() };
+};
+
+Bits128 makePosition(uint32_t icao, bool odd, uint32_t latCpr,
+		uint32_t lonCpr, uint8_t capability = 5) {
+	const uint64_t high = (uint64_t(17) << 43)
+		| (uint64_t(capability) << 40)
+		| (uint64_t(icao) << 16)
+		| (uint64_t(11) << 11);
+	const uint64_t low = (uint64_t(odd) << 58)
+		| (uint64_t(latCpr) << 41)
+		| (uint64_t(lonCpr) << 24);
+	Bits128 frame(high, low);
+	frame.low() |= CRC::compute<112>(frame);
+	return frame;
+}
+
+Bits128 makeIdentity(uint32_t icao, uint8_t capability = 5) {
+	const uint64_t high = (uint64_t(17) << 43)
+		| (uint64_t(capability) << 40)
+		| (uint64_t(icao) << 16)
+		| (uint64_t(5) << 11);
+	Bits128 frame(high, 0);
+	frame.low() = CRC::compute<112>(frame);
+	return frame;
+}
+
+void feedSilence(DemodCore<1, CapturingHandler>& demod, uint32_t bits) {
+	for (uint32_t bit = 0; bit < bits; ++bit) {
+		uint32_t value[] = { 0 };
+		demod.shiftInNewBits(value);
+	}
+}
+
+void feedFrame(DemodCore<1, CapturingHandler>& demod, const Bits128& frame) {
+	for (int bit = 111; bit >= 0; --bit) {
+		uint32_t value[] = { uint32_t(frame.get(bit)) };
+		demod.shiftInNewBits(value);
+	}
+	feedSilence(demod, 16);
+}
+
+} // namespace
+
+int main() {
+	CapturingHandler handler;
+	DemodCore<1, CapturingHandler> demod(handler);
+
+	// A repaired position for a trusted aircraft with no clean odd/even pair
+	// behind it must be rejected (repairs never establish the first position).
+	// 0x12345 becomes trusted via a clean identity frame first.
+	feedFrame(demod, makeIdentity(0x123456));
+	feedSilence(demod, 128);
+	auto firstRepair = makePosition(0x123456, false, 93000, 51372);
+	firstRepair.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, firstRepair);
+	if (handler.longCount != 0)
+		return 1;
+
+	// A CRC-clean even/odd pair establishes the reference position; both
+	// frames are emitted.
+	const auto firstEven = makePosition(0x123456, false, 93000, 51372);
+	feedFrame(demod, firstEven);
+	feedSilence(demod, 128);
+	const auto firstOdd = makePosition(0x123456, true, 74158, 50194);
+	feedFrame(demod, firstOdd);
+	if (handler.longCount != 2)
+		return 2;
+
+	// A single-bit damage repair landing near the established position passes.
+	auto nearby = makePosition(0x123456, false, 93000, 51372);
+	nearby.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, nearby);
+	if (handler.longCount != 3)
+		return 3;
+
+	// A repair that would place the aircraft > 100 km away is rejected.
+	auto farAway = makePosition(0x123456, false, 0, 0);
+	farAway.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, farAway);
+
+	return handler.longCount != 3 ? 4 : 0;
+}

--- a/tests/PositionRepairTest.cpp
+++ b/tests/PositionRepairTest.cpp
@@ -66,41 +66,45 @@ int main() {
 	CapturingHandler handler;
 	DemodCore<1, CapturingHandler> demod(handler);
 
-	// A repaired position for a trusted aircraft with no clean odd/even pair
-	// behind it must be rejected (repairs never establish the first position).
-	// 0x12345 becomes trusted via a clean identity frame first.
+	// Make aircraft 0x123456 trusted with a clean identity pair (the first
+	// sighting seeds trust on the second, separate sighting).
 	feedFrame(demod, makeIdentity(0x123456));
 	feedSilence(demod, 128);
-	auto firstRepair = makePosition(0x123456, false, 93000, 51372);
+	feedFrame(demod, makeIdentity(0x123456, 7));
+	if (handler.longCount != 1)
+		return 1;
+
+	// A repaired position for a trusted aircraft with no clean odd/even pair
+	// behind it must be rejected (repairs never establish the first position).
+	auto firstRepair = makePosition(0x123456, false, 93000, 51372, 7);
 	firstRepair.flip(0);
 	feedSilence(demod, 128);
 	feedFrame(demod, firstRepair);
-	if (handler.longCount != 0)
-		return 1;
-
-	// A CRC-clean even/odd pair establishes the reference position; both
-	// frames are emitted.
-	const auto firstEven = makePosition(0x123456, false, 93000, 51372);
-	feedFrame(demod, firstEven);
-	feedSilence(demod, 128);
-	const auto firstOdd = makePosition(0x123456, true, 74158, 50194);
-	feedFrame(demod, firstOdd);
-	if (handler.longCount != 2)
+	if (handler.longCount != 1)
 		return 2;
 
-	// A single-bit damage repair landing near the established position passes.
-	auto nearby = makePosition(0x123456, false, 93000, 51372);
-	nearby.flip(0);
+	// A CRC-clean even/odd pair establishes the reference position.
+	const auto firstEven = makePosition(0x123456, false, 93000, 51372, 7);
+	feedFrame(demod, firstEven);
 	feedSilence(demod, 128);
-	feedFrame(demod, nearby);
+	const auto firstOdd = makePosition(0x123456, true, 74158, 50194, 7);
+	feedFrame(demod, firstOdd);
 	if (handler.longCount != 3)
 		return 3;
 
+	// A single-bit damage repair landing near the established position passes.
+	auto nearby = makePosition(0x123456, false, 93000, 51372, 7);
+	nearby.flip(0);
+	feedSilence(demod, 128);
+	feedFrame(demod, nearby);
+	if (handler.longCount != 4)
+		return 4;
+
 	// A repair that would place the aircraft > 100 km away is rejected.
-	auto farAway = makePosition(0x123456, false, 0, 0);
+	auto farAway = makePosition(0x123456, false, 0, 0, 7);
 	farAway.flip(0);
 	feedSilence(demod, 128);
 	feedFrame(demod, farAway);
 
-	return handler.longCount != 3 ? 4 : 0;
+	return handler.longCount != 4 ? 5 : 0;
 }


### PR DESCRIPTION
## Summary

A noise frame whose 24-bit CRC happens to collide inserts a brand-new address,
marks it trusted and forwards it; the same collision then licenses
address-parity frames for the fabricated aircraft. Sighting statistics say
this loop is what mints fake planes.

Fix: hold the first CRC-clean DF17/18/19 frame of an unknown address for up to
two seconds. A second sighting of the same address within the window promotes the aircraft
to trusted and emits the current frame. The held frame is used only for
corroboration and CPR state, then discarded: emitting it later would put an old
MLAT timestamp after newer output and attach the confirming frame's RSSI.

## Changes

- `DemodCore.hpp`: `PendingFirstFrame` confirmation logic in
  `handleExtSquitterLongMessage`, trust escalation only after confirmation,
  and expiry handling. The current frame follows the normal output path; the
  held frame is never emitted retroactively.
- `tests/df17_first_frame_test`: held frame is never emitted; a second sighting
  (even at a different CA) emits only the confirming frame; output remains in
  timestamp order when an unrelated aircraft appears in between; a repair
  candidate cannot confirm the address; the pending sighting expires.

## Notes

- Drops the first sighting of every new aircraft and requires one confirmation
  frame; a busy receiver stays well under the 1024-entry table. Window and
  minimum separation are `FirstFrameConfirmationMinTicks/MaxTicks`
  (100 us / 2 s) and deserve a separate tuning discussion.
- Stacked on #48, #49 and #51 and recommended as the last piece so the
  behavior change is reviewed in isolation.