### PR TITLE
DemodCore: mark the preamble gate parameter maybe_unused

### DIFF
--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -76,7 +76,7 @@ public:
 
 	/// True when the preamble in front of this candidate is strong enough to be
 	/// a real transmission. Disabled unless STREAM1090_PREAMBLE_GATE is defined.
-	bool preambleConfirms(int streamIndex) noexcept {
+	bool preambleConfirms([[maybe_unused]] int streamIndex) noexcept {
 	#if defined(STREAM1090_PREAMBLE_GATE) && STREAM1090_PREAMBLE_GATE
 		if (m_preambleFn == nullptr)
 			return false;


### PR DESCRIPTION
`preambleConfirms` uses `streamIndex` only inside the `STREAM1090_PREAMBLE_GATE` branch, so any translation unit compiled without that definition warns under `-Wextra`:

```
include/DemodCore.hpp:79:28: warning: unused parameter 'streamIndex' [-Wunused-parameter]
   79 |         bool preambleConfirms(int streamIndex) noexcept {
```

`[[maybe_unused]]` states the intent — the parameter is used in one configuration and not in the other.
