### PR TITLE
rtl-sdr-blog: fix the libusb link on macOS

### DIFF
--- a/thirdparty/rtl-sdr-blog/CMakeLists.txt
+++ b/thirdparty/rtl-sdr-blog/CMakeLists.txt
@@ -19,7 +19,11 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.10.0)
+# 3.13 for target_link_directories(), which src/CMakeLists.txt needs to put
+# LIBUSB_LIBRARY_DIRS on the link line. Declared here rather than in the
+# parent project so it only binds builds that actually add this directory,
+# i.e. -DENABLE_RTLSDR_BLOG=ON.
+cmake_minimum_required(VERSION 3.13)
 
 # workaround for https://gitlab.kitware.com/cmake/cmake/issues/16967
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")

--- a/thirdparty/rtl-sdr-blog/src/CMakeLists.txt
+++ b/thirdparty/rtl-sdr-blog/src/CMakeLists.txt
@@ -21,6 +21,14 @@
 add_library(rtlsdr SHARED librtlsdr.c
   tuner_e4k.c tuner_fc0012.c tuner_fc0013.c tuner_fc2580.c tuner_r82xx.c)
 target_link_libraries(rtlsdr ${LIBUSB_LIBRARIES} ${THREADS_PTHREADS_LIBRARY})
+# LIBUSB_LIBRARIES from pkg_check_modules() is a bare lib name (e.g.
+# "usb-1.0"), not a full path, so the linker also needs LIBUSB_LIBRARY_DIRS on
+# its search path. PUBLIC so it propagates to anything linking against
+# rtlsdr, not just this target. Linux distros usually keep libusb in a
+# default linker search path so this went unnoticed there, but Homebrew's
+# /opt/homebrew (or /usr/local) is not searched by default, so linking fails
+# on macOS with "library 'usb-1.0' not found".
+target_link_directories(rtlsdr PUBLIC ${LIBUSB_LIBRARY_DIRS})
 target_include_directories(rtlsdr PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -39,7 +47,13 @@ generate_export_header(rtlsdr)
 ########################################################################
 add_library(rtlsdr_static STATIC librtlsdr.c
   tuner_e4k.c tuner_fc0012.c tuner_fc0013.c tuner_fc2580.c tuner_r82xx.c)
-target_link_libraries(rtlsdr ${LIBUSB_LIBRARIES} ${THREADS_PTHREADS_LIBRARY})
+# rtlsdr_static, not rtlsdr: this line named the shared target, so libusb was
+# attached to it twice ("ld: warning: ignoring duplicate libraries") while the
+# static variant got none at all. Nothing in this tree links rtlsdr_static, so
+# it built anyway, but it is in INSTALL_TARGETS and anyone linking the
+# installed librtlsdr.a would have had to supply libusb themselves.
+target_link_libraries(rtlsdr_static ${LIBUSB_LIBRARIES} ${THREADS_PTHREADS_LIBRARY})
+target_link_directories(rtlsdr_static PUBLIC ${LIBUSB_LIBRARY_DIRS})
 target_include_directories(rtlsdr_static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
Building with `-DENABLE_RTLSDR_BLOG=ON` fails to link on macOS:

```
ld: warning: ignoring duplicate libraries: '-lusb-1.0'
ld: library 'usb-1.0' not found
```

Two independent defects in `thirdparty/rtl-sdr-blog/src/CMakeLists.txt`, both fixed here.

### The library directory never reaches the linker

`pkg_check_modules()` sets `LIBUSB_LIBRARIES` to a bare library name, not a full path:

```
LIBUSB_LIBRARIES:INTERNAL=usb-1.0
LIBUSB_LIBRARY_DIRS:INTERNAL=/opt/homebrew/Cellar/libusb/1.0.30/lib
```

Only the first is used, so the linker is told to find `usb-1.0` with no `-L` to find it in. On distributions that keep libusb in a default search path this resolves by accident; under Homebrew (`/opt/homebrew`, or `/usr/local` on Intel) it does not.

Fixed with `target_link_directories(... PUBLIC ${LIBUSB_LIBRARY_DIRS})`, `PUBLIC` so the path propagates to whatever links the target — stream1090 itself, in this case.

### The static variant links the wrong target

Under "Setup static library variant", `target_link_libraries()` named `rtlsdr` rather than `rtlsdr_static`. libusb was therefore attached to the shared target twice, which is the `ignoring duplicate libraries` warning above, while `rtlsdr_static` got none at all. Nothing in this tree links `rtlsdr_static`, so it built regardless — but it is listed in `INSTALL_TARGETS`, so anyone linking the installed `librtlsdr.a` had to supply libusb themselves.

### CMake floor

`target_link_directories()` is CMake 3.13. The bump is declared in the vendored subproject's own `CMakeLists.txt`, not in the top-level one: stream1090 itself uses nothing newer than 3.10, and this directory is only added under `-DENABLE_RTLSDR_BLOG=ON`, so the higher floor binds exactly the builds that need it. A build that never enables the vendored fork still configures on 3.10.

The `VERSION_LESS "3.12.0"` workaround just below the bumped line is dead now. I left it alone rather than fold unrelated cleanup of vendored code into a link fix — happy to drop it if you would rather.

### Verification

macOS 15 / arm64, Apple clang, Homebrew libusb 1.0.30, with no `LIBRARY_PATH` in the environment:

| | before | after |
|---|---|---|
| `-DENABLE_RTLSDR_BLOG=ON` | fails to link | builds, 0 linker warnings, 8/8 tests |
| `-DENABLE_RTLSDR_BLOG=OFF` | builds | builds, 8/8 tests |

`otool -L` confirms the resulting binary picks up `/opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib`.

Linux is unaffected either way: it was already finding libusb through the default search path, and `target_link_directories()` simply adds a path it was already using.
