### PR TITLE
RTL-SDR: prefer exact serial matches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(BUILD_TESTING)
     stream1090_add_test(sampler_test tests/SamplerTest.cpp)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
+    stream1090_add_test(rtlsdr_serial_test tests/RtlSdrSerialTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/configs/rtlsdr.ini
+++ b/configs/rtlsdr.ini
@@ -4,7 +4,8 @@
 # pairs are processed in order as they appear in the file.
 [rtlsdr]
 
-# Optional: select a specific device by serial number
+# Optional: select a device by its exact serial string. If no exact match is
+# found, a positive decimal value also matches a zero-padded decimal serial.
 # serial = 00000001
 
 # Center frequency in Hz (default: 1090 MHz for ADS-B)
@@ -64,5 +65,4 @@ bias_tee = false
 #      48.3 |  14 |  14 |  8  |
 #      48.8 |  15 |  15 |  8  |
 #      49.6 |  15 |  14 |  8  |
-
 

--- a/include/devices/RtlSdrSerial.hpp
+++ b/include/devices/RtlSdrSerial.hpp
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace RtlSdrSerial {
+
+inline bool parsePositiveDecimal(const std::string& serial,
+                                 uint64_t& value) noexcept {
+    if (serial.empty())
+        return false;
+
+    value = 0;
+    const char* first = serial.data();
+    const char* last = first + serial.size();
+    const auto result = std::from_chars(first, last, value, 10);
+    return result.ec == std::errc{} && result.ptr == last && value != 0;
+}
+
+inline int resolveIndex(const std::string& requested,
+                        const std::vector<std::string>& available) noexcept {
+    // RTL-SDR serials are opaque strings. Do not reinterpret a valid exact
+    // match merely because it happens to look decimal or hexadecimal.
+    for (std::size_t i = 0; i < available.size(); ++i) {
+        if (available[i] == requested)
+            return static_cast<int>(i);
+    }
+
+    // Preserve compatibility with old configurations that used e.g.
+    // "serial = 2" for a dongle whose EEPROM contains "00000002".
+    uint64_t requestedValue = 0;
+    if (!parsePositiveDecimal(requested, requestedValue))
+        return -1;
+
+    for (std::size_t i = 0; i < available.size(); ++i) {
+        uint64_t availableValue = 0;
+        if (parsePositiveDecimal(available[i], availableValue)
+                && availableValue == requestedValue)
+            return static_cast<int>(i);
+    }
+
+    return -1;
+}
+
+} // namespace RtlSdrSerial

--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -5,8 +5,11 @@
  * Public License v3.0. See the top-level LICENSE file for details.
  */
 #include "devices/RtlSdrDevice.hpp"
+#include "devices/RtlSdrSerial.hpp"
 #include "Logger.hpp"
 #include <iostream>
+#include <string>
+#include <vector>
 
 static void rtlsdr_callback(unsigned char* buf, uint32_t len, void* ctx) {
     auto* self = static_cast<RtlSdrDevice*>(ctx);
@@ -26,17 +29,18 @@ bool RtlSdrDevice::open_with_serial(const std::string& serial) {
         return open_with_serial(static_cast<uint64_t>(0));
     }
 
-    std::size_t pos = 0;
-    try {
-        uint64_t numericSerial = std::stoull(serial, &pos, 0);
-        if (pos == serial.size()) {
-            return open_with_serial(numericSerial);
-        }
-    } catch (...) {
-        // Not numeric, attempt string-based lookup below.
+    const int deviceCount = static_cast<int>(rtlsdr_get_device_count());
+    std::vector<std::string> available;
+    available.reserve(deviceCount > 0 ? static_cast<std::size_t>(deviceCount) : 0);
+    for (int i = 0; i < deviceCount; ++i) {
+        char deviceSerial[256]{};
+        if (rtlsdr_get_device_usb_strings(i, nullptr, nullptr, deviceSerial) == 0)
+            available.emplace_back(deviceSerial);
+        else
+            available.emplace_back();
     }
 
-    int index = rtlsdr_get_index_by_serial(serial.c_str());
+    const int index = RtlSdrSerial::resolveIndex(serial, available);
     if (index < 0) {
         Log::error("RtlSdrDevice") << "No RTL-SDR device found with serial '"
                   << serial << "'";

--- a/tests/RtlSdrSerialTest.cpp
+++ b/tests/RtlSdrSerialTest.cpp
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "devices/RtlSdrSerial.hpp"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(const char* what, int got, int want) {
+    if (got != want) {
+        std::printf("FAIL %s: expected index %d, got %d\n", what, want, got);
+        failures++;
+    }
+}
+
+int resolve(const char* requested, std::initializer_list<const char*> serials) {
+    std::vector<std::string> available;
+    for (const char* serial : serials)
+        available.emplace_back(serial);
+    return RtlSdrSerial::resolveIndex(requested, available);
+}
+
+} // namespace
+
+int main() {
+    // A serial is an opaque string. Exact identity must win even when another
+    // device has a numerically equivalent spelling and appears first.
+    check("zero-padded exact match",
+          resolve("00000002", {"2", "00000002"}), 1);
+    check("short exact match",
+          resolve("2", {"00000002", "2"}), 1);
+    check("hex-looking exact match",
+          resolve("0x1A", {"26", "0x1A"}), 1);
+    check("all-zero exact match",
+          resolve("00000000", {"11111111", "00000000"}), 1);
+    check("alphanumeric exact match",
+          resolve("ADSBX-ORANGE-1090", {"00000001", "ADSBX-ORANGE-1090"}), 1);
+
+    // Preserve the pre-string-serial convenience: a short decimal value may
+    // select a conventional zero-padded RTL-SDR serial, but only after exact
+    // lookup failed.
+    check("legacy decimal fallback",
+          resolve("2", {"00000001", "00000002"}), 1);
+    check("legacy decimal eight fallback",
+          resolve("8", {"00000008", "00000009"}), 0);
+
+    // Zero is the old sentinel for "first device", not a safe alias for an
+    // explicitly requested serial. Partial or non-decimal strings must not be
+    // reinterpreted either.
+    check("zero has no numeric fallback",
+          resolve("0", {"00000000"}), -1);
+    check("partial decimal has no fallback",
+          resolve("8suffix", {"00000008"}), -1);
+    check("missing serial",
+          resolve("missing", {"00000001", "00000002"}), -1);
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Treat RTL-SDR EEPROM serials as opaque strings and prefer an exact match.
- Preserve the common legacy shorthand where a positive decimal value such as "2" selects a zero-padded serial such as "00000002".
- Add hardware-independent tests for exact-match precedence, decimal fallback, alphanumeric serials, zero, partial values, and missing devices.
- Document the matching rules in the sample RTL-SDR configuration.

## Why

The current code parses numeric-looking serials before asking librtlsdr for an exact string match. That makes selection depend on enumeration order when two devices have numerically equivalent but textually different serials, for example "2" and "00000002". A request for the latter can therefore open the former.

The same ambiguity affects hex-looking serial strings such as "0x1A" versus "26", while an all-zero serial can be confused with the existing first-device sentinel. RTL-SDR EEPROM serials are strings and may also be alphanumeric, as supported since #13, so exact identity should take precedence over numeric convenience.

## Matching behavior

1. Return an exact serial-string match first.
2. If no exact match exists, accept a positive base-10 value and compare it numerically with positive decimal device serials.
3. Do not reinterpret zero, partial numeric strings, or hex-looking strings as aliases; those still work when they are exact serials.
4. Fail cleanly when no match exists.

This retains the useful "serial = 2" compatibility path without allowing it to override an explicitly requested serial string.

## Validation

- Release build with AppleClang, Airspy, and system librtlsdr enabled.
- Full CTest suite: 10/10 tests passed.
- Exact selection behavior was also verified with two RTL-SDR Blog V3 dongles using serials "00000001" and "00000002".