### PR TITLE
RTL-SDR: avoid zero-frequency retune at startup

### DIFF
--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -59,16 +59,14 @@ bool RtlSdrDevice::open_with_serial(const std::string& serial) {
         return true;
     };
 
-    if (!check("rtlsdr_set_direct_sampling(0)",
-            rtlsdr_set_direct_sampling(m_dev, 0)))
+    // Set the frequency before the sample rate: R820T bandwidth setup retunes
+    // the current frequency, and immediately after open() that value is zero.
+    if (!check("rtlsdr_set_center_freq",
+            rtlsdr_set_center_freq(m_dev, 1090000000)))
         return false;
 
     if (!check("rtlsdr_set_sample_rate",
             rtlsdr_set_sample_rate(m_dev, getSampleRate())))
-        return false;
-
-    if (!check("rtlsdr_set_center_freq",
-            rtlsdr_set_center_freq(m_dev, 1090000000)))
         return false;
 
     if (!check("rtlsdr_reset_buffer",
@@ -119,16 +117,14 @@ bool RtlSdrDevice::open_with_serial(uint64_t serial) {
         return true;
     };
 
-    if (!check("rtlsdr_set_direct_sampling(0)",
-            rtlsdr_set_direct_sampling(m_dev, 0)))
-        return false;
-    
-    if (!check("rtlsdr_set_sample_rate",
-            rtlsdr_set_sample_rate(m_dev, getSampleRate())))
-        return false;
-
+    // Set the frequency before the sample rate: R820T bandwidth setup retunes
+    // the current frequency, and immediately after open() that value is zero.
     if (!check("rtlsdr_set_center_freq",
             rtlsdr_set_center_freq(m_dev, 1090000000)))
+        return false;
+
+    if (!check("rtlsdr_set_sample_rate",
+            rtlsdr_set_sample_rate(m_dev, getSampleRate())))
         return false;
 
     if (!check("rtlsdr_reset_buffer",


### PR DESCRIPTION
## Summary

Avoid an invalid zero-frequency retune while opening R820T/R820T2 RTL-SDR devices.

`rtlsdr_open()` zeroes the device state and already initializes the tuner, so direct
sampling is off and the stored frequency is 0. Calling `rtlsdr_set_direct_sampling(dev, 0)`
right after open is therefore a no-op except for one side effect: it ends with
`rtlsdr_set_center_freq(dev, dev->freq)`. `rtlsdr_set_sample_rate()` has the same side
effect through `tuner->set_bw` -> `r820t_set_bw()`.

With `dev->freq == 0`, the rtl-sdr-blog fork's automatic HF direct-sampling path kicks in
(`freq < 24 MHz && tuner == R820T && !Blog V4`, librtlsdr.c:904): it switches to input 2 and
puts the tuner into standby via `tuner->exit()`, so the subsequent 1090 MHz PLL lock fails.
Upstream osmocom librtlsdr has no auto-switch and is unaffected.

Before, on both tested receivers:

    Found Rafael Micro R820T tuner
    Disabled direct sampling mode
    Enabled direct sampling mode, input 2
    [R82XX] PLL not locked!
    Disabled direct sampling mode

The fix drops the redundant direct-sampling call and sets 1090 MHz before the sample rate,
so the bandwidth setup reapplies a valid frequency instead of zero.

After:

    Found Rafael Micro R820T tuner

Decoding starts normally without entering direct sampling or reporting a PLL failure.

## Validation

Tested on macOS with two RTL-SDR Blog V3 receivers:

- serials 00000001 and 00000002;
- 2.4 Msps input, manual gain 49.6 dB, AGC disabled;
- clean startup and normal decoding on both devices;
- bundled RTL-SDR Blog library: 9/9 tests passed;
- system librtlsdr from Homebrew (no auto-switch, non-regression check): 9/9 tests passed
  and clean hardware startup.

The change is confined to `RtlSdrDevice`; no bundled librtlsdr modifications are required.
The same reorder is applied to both `open_with_serial` overloads, which still duplicate the
init sequence - factoring it out is left to a follow-up. Touches the same file as #56, in a
different region.
