### PR TITLE
Fail startup when a device setting cannot be applied

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if(BUILD_TESTING)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
     stream1090_add_test(rtlsdr_serial_test tests/RtlSdrSerialTest.cpp)
+    stream1090_add_test(device_config_test tests/DeviceConfigTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ There is now basic experimental support for the SIGHUP signal. This signal can b
 
 Clearly, there are some things you will not be able to change like serial (and sample rate which is not part of the ini anyways). The purpose is to not have to restart for adjusting gain settings. For airspy, make sure you know what you are doing when switching between manual and simple gain controls.
 
+Reloaded settings are validated as a complete set before they are sent to the device. Invalid files leave the previous settings active. If the hardware rejects a setting after validation, stream1090 shuts down because the device may already be partly reconfigured; restart it after correcting the file.
+
 ### Advanced RTL-SDR gain controls
 
 If you have an RTL-SDR device and still not happy, you can push things further. Stream1090 comes with a hacked version of the [RTL-SDR-BLOG](https://github.com/rtlsdrblog/rtl-sdr-blog) lib which in turn is a fork of librtlsdr. There are two aspects here.

--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -105,7 +105,8 @@ public:
         
         // tell the device to read all properties required to open it
         Log::info("Stream1090","Reading initial properties from the ini file");
-        m_device->applyConfigPreOpen(cfg);
+        if (!m_device->applyConfigPreOpen(cfg))
+            return false;
 
         
         // let us try to open the device
@@ -118,10 +119,7 @@ public:
 
         // device is ready, apply all the other properties
         Log::info("Stream1090","Device is open. Reading the ini file.");
-        m_device->applyConfigPostOpen(cfg);
-        
-        // we do not care if any of the properties did not work
-        return true;
+        return m_device->applyConfigPostOpen(cfg);
    }
 
     static constexpr auto constructMessageHandler(SampleStream<SamplerType>& sampleStream) {
@@ -203,10 +201,27 @@ public:
                     ProcessSignals::clearReload();
                     Log::info("Stream1090", "Re-reading config file.");
 
+                    const auto previousConfig = m_runtimeVars.deviceConfigSection;
                     if (reloadDeviceConfig()) {
-                        Log::info("Stream1090", "Applying new configuration.");
-                        m_device->applyConfigPostOpen(m_runtimeVars.deviceConfigSection);
+                        const auto& newConfig = m_runtimeVars.deviceConfigSection;
+                        if (!m_device->validateConfigPostOpen(newConfig)) {
+                            m_runtimeVars.deviceConfigSection = previousConfig;
+                            Log::warn("Stream1090", "Reloaded device configuration "
+                                      "is invalid. Keeping old settings.");
+                        } else {
+                            Log::info("Stream1090", "Applying new configuration.");
+                            if (!m_device->applyConfigPostOpen(newConfig)) {
+                                Log::error("Stream1090", "Hardware rejected a "
+                                           "validated setting. The device may be "
+                                           "partly configured; shutting down.");
+                                m_device->shutdownWriter();
+                                ProcessSignals::handle_sigint(0);
+                                intendedShutdown = false;
+                                break;
+                            }
+                        }
                     } else {
+                        m_runtimeVars.deviceConfigSection = previousConfig;
                         Log::warn("Stream1090", "Reload failed. Keeping old settings.");
                     }
                 }

--- a/include/devices/AirspyDevice.hpp
+++ b/include/devices/AirspyDevice.hpp
@@ -32,15 +32,17 @@ public:
     bool setBiasTee(bool enabled);
 
     // Called before opening the device to parse the serial
-    void applyConfigPreOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPreOpen(const IniConfig::Section& cfg) override;
 
     // Reload hook
-    void applyConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool validateConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPostOpen(const IniConfig::Section& cfg) override;
 
 private:
     bool open_with_serial(uint64_t serial);
     bool tryEnablingPacking();
-    bool applySetting(const std::string& key, const std::string& value);
+    bool applySetting(const std::string& key, const std::string& value) override;
+    bool validateSetting(const std::string& key, const std::string& value) const;
 
     struct ShadowState {
         uint32_t frequency = 1090000000;

--- a/include/devices/InputDeviceBase.hpp
+++ b/include/devices/InputDeviceBase.hpp
@@ -9,8 +9,61 @@
 #include "Sampler.hpp"
 #include "RingBuffer.hpp"
 #include "IniConfig.hpp"
+#include "Logger.hpp"
 #include <string>
 #include <atomic>
+#include <cstdint>
+#include <exception>
+
+namespace DeviceSettings {
+
+inline bool parseInt(const std::string& value, int& out) noexcept {
+    try {
+        std::size_t consumed = 0;
+        out = std::stoi(value, &consumed);
+        return consumed == value.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+inline bool parseUnsigned(const std::string& value, uint32_t& out) noexcept {
+    if (value.empty() || value.front() == '-')
+        return false;
+    try {
+        std::size_t consumed = 0;
+        const auto parsed = std::stoul(value, &consumed);
+        if (consumed != value.size() || parsed > UINT32_MAX)
+            return false;
+        out = static_cast<uint32_t>(parsed);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline bool parseFloat(const std::string& value, float& out) noexcept {
+    bool hasDigit = false;
+    for (const char ch : value) {
+        if (ch >= '0' && ch <= '9') {
+            hasDigit = true;
+            continue;
+        }
+        if (ch != '+' && ch != '-' && ch != '.' && ch != 'e' && ch != 'E')
+            return false;
+    }
+    if (!hasDigit)
+        return false;
+    try {
+        std::size_t consumed = 0;
+        out = std::stof(value, &consumed);
+        return consumed == value.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace DeviceSettings
 
 template<typename T>
 class InputDeviceBase {
@@ -32,13 +85,36 @@ public:
     virtual void close() = 0;
 
     // Called before open() is called to parse things like serial, packing etc.
-    virtual void applyConfigPreOpen(const IniConfig::Section&) {
+    virtual bool applyConfigPreOpen(const IniConfig::Section&) {
         // we do not do anything as default        
+        return true;
     };
 
+    virtual bool applySetting(const std::string& key, const std::string& value) = 0;
+
+    bool applySettingSafely(const std::string& key, const std::string& value) noexcept {
+        try {
+            return applySetting(key, value);
+        } catch (const std::exception& error) {
+            Log::error("InputDevice")
+                << "invalid value for setting '" << key << "': '" << value
+                << "' (" << error.what() << ")";
+        } catch (...) {
+            Log::error("InputDevice")
+                << "invalid value for setting '" << key << "': '" << value
+                << "'";
+        }
+        return false;
+    }
+
     // Called by the watchdog after SIGHUP
-    virtual void applyConfigPostOpen(const IniConfig::Section&) {
+    virtual bool validateConfigPostOpen(const IniConfig::Section&) {
+        return true;
+    }
+
+    virtual bool applyConfigPostOpen(const IniConfig::Section&) {
         // we do not do anything as default        
+        return true;
     };
 
     // Called by device callback threads

--- a/include/devices/RtlSdrDevice.hpp
+++ b/include/devices/RtlSdrDevice.hpp
@@ -34,15 +34,17 @@ public:
     bool setVgaGain(int value);
     
     // Called before opening the device to parse the serial
-    void applyConfigPreOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPreOpen(const IniConfig::Section& cfg) override;
 
     // Reload hook
-    void applyConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool validateConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPostOpen(const IniConfig::Section& cfg) override;
     
 private:
     bool open_with_serial(uint64_t serial = 0);
     bool open_with_serial(const std::string& serial);
-    bool applySetting(const std::string& key, const std::string& value);
+    bool applySetting(const std::string& key, const std::string& value) override;
+    bool validateSetting(const std::string& key, const std::string& value) const;
 
     int nearestGain(int requested);
 
@@ -66,4 +68,3 @@ private:
     uint64_t m_actualSerial = 0;
     std::string m_serialString = "";
 };
-

--- a/src/devices/AirspyDevice.cpp
+++ b/src/devices/AirspyDevice.cpp
@@ -314,20 +314,31 @@ bool AirspyDevice::applySetting(const std::string& key, const std::string& value
     return false;
 }
 
+bool AirspyDevice::validateSetting(const std::string& key,
+                                  const std::string& value) const {
+    int integer = 0;
+    uint32_t frequency = 0;
+    if (key == "frequency")
+        return DeviceSettings::parseUnsigned(value, frequency);
+    if (key == "linearity_gain" || key == "sensitivity_gain"
+            || key == "lna_gain" || key == "mixer_gain" || key == "vga_gain")
+        return DeviceSettings::parseInt(value, integer);
+    return key == "bias_tee";
+}
 
-void AirspyDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
+
+bool AirspyDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
     for (auto& [key, value] : cfg) {
 
         if (key == "serial") {
             try {
                 std::size_t pos = 0;
                 uint64_t serial = std::stoull(value, &pos, 0);
-                if (pos != value.size()) {
-                    m_serial = 0;
-                }
+                if (pos != value.size())
+                    return false;
                 m_serial = serial;
             } catch (...) {
-                m_serial = 0;
+                return false;
             }   
         }
 
@@ -335,13 +346,29 @@ void AirspyDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
             m_packingEnabled = (value == "1" || value == "true" || value == "on");
         }
     }
+    return true;
 }
 
 
 // ----------------------
 // Reload logic
 // ----------------------
-void AirspyDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+bool AirspyDevice::validateConfigPostOpen(const IniConfig::Section& cfg) {
+    for (const auto& [key, value] : cfg) {
+        if (key == "serial" || key == "packing")
+            continue;
+        if (!validateSetting(key, value)) {
+            Log::error("AirspyDevice") << "invalid setting '" << key
+                                       << " = " << value << "'";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool AirspyDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+    if (!validateConfigPostOpen(cfg))
+        return false;
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
@@ -349,8 +376,8 @@ void AirspyDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
         if (key == "packing")
             continue; // immutable
 
-        applySetting(key, value);
+        if (!applySettingSafely(key, value))
+            return false;
     }
+    return true;
 }
-
-

--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -405,24 +405,57 @@ bool RtlSdrDevice::applySetting(const std::string& key, const std::string& value
     return false;
 }
 
+bool RtlSdrDevice::validateSetting(const std::string& key,
+                                  const std::string& value) const {
+    int integer = 0;
+    uint32_t unsignedValue = 0;
+    float gain = 0.0f;
+    if (key == "frequency" || key == "tuner_bandwidth")
+        return DeviceSettings::parseUnsigned(value, unsignedValue);
+    if (key == "gain")
+        return DeviceSettings::parseFloat(value, gain);
+    if (key == "ppm" || key == "lna_gain" || key == "mixer_gain"
+            || key == "vga_gain")
+        return DeviceSettings::parseInt(value, integer);
+    return key == "agc" || key == "bias_tee" || key == "offset_tuning";
+}
 
-void RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
+
+bool RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
             m_serialString = value;
     }
+    return true;
 }
 
 // ----------------------
 // Reload logic
 // ----------------------
-void RtlSdrDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+bool RtlSdrDevice::validateConfigPostOpen(const IniConfig::Section& cfg) {
+    for (const auto& [key, value] : cfg) {
+        if (key == "serial")
+            continue;
+        if (!validateSetting(key, value)) {
+            Log::error("RtlSdrDevice") << "invalid setting '" << key
+                                       << " = " << value << "'";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool RtlSdrDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+    if (!validateConfigPostOpen(cfg))
+        return false;
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
             continue; // immutable
 
-        applySetting(key, value);
+        if (!applySettingSafely(key, value))
+            return false;
     }
+    return true;
 }

--- a/tests/DeviceConfigTest.cpp
+++ b/tests/DeviceConfigTest.cpp
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "devices/InputDeviceBase.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void requireImpl(bool condition, int line) {
+    if (!condition) {
+        std::fprintf(stderr, "requirement failed at line %d\n", line);
+        std::abort();
+    }
+}
+
+#define require(condition) requireImpl((condition), __LINE__)
+
+class NullWriter : public IAsyncWriter<int> {
+public:
+    size_t write(const int*, size_t n) override { return n; }
+    void shutdown() override {}
+};
+
+class TestDevice : public InputDeviceBase<int> {
+public:
+    explicit TestDevice(IAsyncWriter<int>& writer)
+        : InputDeviceBase<int>(Rate_1_0_Mhz, writer) {}
+
+    bool open() override { return true; }
+    bool start() override { return true; }
+    void stop() override {}
+    void close() override {}
+
+    bool applySetting(const std::string&, const std::string& value) override {
+        if (value == "invalid")
+            throw std::invalid_argument("invalid test value");
+        return value == "accepted";
+    }
+};
+
+} // namespace
+
+int main() {
+    NullWriter writer;
+    TestDevice device(writer);
+
+    require(device.applySettingSafely("gain", "accepted"));
+    require(!device.applySettingSafely("gain", "rejected"));
+    require(!device.applySettingSafely("gain", "invalid"));
+
+    int integer = 0;
+    uint32_t unsignedValue = 0;
+    float floating = 0.0f;
+    require(DeviceSettings::parseInt("-12", integer) && integer == -12);
+    require(!DeviceSettings::parseInt("", integer));
+    require(!DeviceSettings::parseInt("12dB", integer));
+    require(!DeviceSettings::parseInt("99999999999999999999", integer));
+    require(DeviceSettings::parseUnsigned("1090000000", unsignedValue)
+            && unsignedValue == 1090000000);
+    require(!DeviceSettings::parseUnsigned("", unsignedValue));
+    require(!DeviceSettings::parseUnsigned("-1", unsignedValue));
+    require(!DeviceSettings::parseUnsigned("4294967296", unsignedValue));
+    require(DeviceSettings::parseFloat("49.6", floating)
+            && floating == 49.6f);
+    require(DeviceSettings::parseFloat("1e2", floating)
+            && floating == 100.0f);
+    require(!DeviceSettings::parseFloat("", floating));
+    require(!DeviceSettings::parseFloat("49.6dB", floating));
+    require(!DeviceSettings::parseFloat("nan", floating));
+    require(!DeviceSettings::parseFloat("inf", floating));
+}


### PR DESCRIPTION
`applySetting()` parses ini values with `std::stoul`, `std::stof` and `std::stoi`, and nothing catches what they throw. A single malformed value is enough: with `gain = abc` in the file the exception escapes `applyConfigPostOpen()` and calls `std::terminate`. The user sees a crash with no indication of which key caused it.

The return value was not used either. `applyConfigPostOpen()` looped over the section discarding every result, under a comment saying *"we do not care if any of the properties did not work"*. A key the device rejects, or one it does not recognise, was accepted in silence and the receiver ran with a configuration that is not the one written in the file. For a device whose settings are only observable through the messages it decodes, that is the worst failure mode there is: a measurement taken with a setting that never applied is indistinguishable from one taken with the setting the user believes is in force.

## What changes

- `applySetting()` becomes a pure virtual on `InputDeviceBase`, which now offers `applySettingSafely()`: it catches the exception, names the offending key and value, and turns it into a `false`.
- `applyConfigPreOpen()` and `applyConfigPostOpen()` return `bool`, and `MainInstance` propagates that, so a setting that cannot be applied stops the program at startup instead of being ignored.

## The policy change this implies

Any key the device does not handle now fails the startup, because `applySetting()` returns `false` for unknown keys as well as for keys whose device call failed. This is deliberate: refusing to start is preferable to running with a parameter that has no effect, or that was applied at a value other than the one in the file.

The shipped `configs/rtlsdr.ini` and `configs/airspy.ini` are unaffected — every key they set is handled, and `serial` and `packing` are skipped explicitly. On SIGHUP, the complete new section is validated before any hardware call. A malformed or unknown value restores the previous parsed configuration and leaves the device untouched. If a validated setting is nevertheless rejected by the driver, stream1090 shuts down cleanly because earlier settings may already have reached the hardware.

One more configuration that used to be accepted now is not: an Airspy `serial` that does not parse. It used to fall back to `m_serial = 0`, which means "open the first device found", so a typo in the serial silently opened a different dongle than the one asked for — the same failure the RTL-SDR serial lookup is being fixed for in #56. It now stops the startup instead. Worth flagging because a config that appeared to work (one Airspy present, unparsable serial) will now be rejected.

## Testing

`tests/DeviceConfigTest.cpp` covers applied and refused settings plus strict integer, unsigned and finite-float parsing (including empty, trailing-junk, negative-unsigned, NaN and infinity inputs). No hardware needed.

Rebased onto current `main`, including #61, #57 and #56. Full suite green on macOS/arm64 with the system librtlsdr and with `-DENABLE_RTLSDR_BLOG=ON`: 11/11.

## Relation to the other RTL-SDR PRs

Rebased after #61, #57 and #56 merged. The adjacent `CMakeLists.txt` additions from #56 are both retained. #59 and #60 remain stacked on this PR.
