### PR TITLE
RTL-SDR: reject configurations the device would not apply

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if(BUILD_TESTING)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
     stream1090_add_test(rtlsdr_serial_test tests/RtlSdrSerialTest.cpp)
+    stream1090_add_test(device_config_test tests/DeviceConfigTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,20 @@ if(BUILD_TESTING)
     stream1090_add_test(low_pass_filter_test tests/LowPassFilterTest.cpp)
     stream1090_add_test(sampler_test tests/SamplerTest.cpp)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
+
+    # This test compiles the device too, so it only exists where the RTL-SDR
+    # backend was built.
+    if(DEVICE_SOURCES MATCHES "RtlSdrDevice")
+        add_executable(rtlsdr_config_validation_test
+            tests/RtlSdrConfigValidationTest.cpp
+            src/devices/RtlSdrDevice.cpp)
+        target_include_directories(rtlsdr_config_validation_test PRIVATE
+            include ${DEVICE_INCLUDE_DIRS})
+        target_compile_options(rtlsdr_config_validation_test PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+        target_compile_definitions(rtlsdr_config_validation_test PRIVATE ${DEVICE_DEFINITIONS})
+        target_link_libraries(rtlsdr_config_validation_test PRIVATE ${DEVICE_LIBS})
+        add_test(NAME rtlsdr_config_validation_test COMMAND rtlsdr_config_validation_test)
+    endif()
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
     stream1090_add_test(rtlsdr_serial_test tests/RtlSdrSerialTest.cpp)
     stream1090_add_test(device_config_test tests/DeviceConfigTest.cpp)

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ There is now basic experimental support for the SIGHUP signal. This signal can b
 
 Clearly, there are some things you will not be able to change like serial (and sample rate which is not part of the ini anyways). The purpose is to not have to restart for adjusting gain settings. For airspy, make sure you know what you are doing when switching between manual and simple gain controls.
 
+Reloaded settings are validated as a complete set before they are sent to the device. Invalid files leave the previous settings active. If the hardware rejects a setting after validation, stream1090 shuts down because the device may already be partly reconfigured; restart it after correcting the file.
+
 ### Advanced RTL-SDR gain controls
 
 If you have an RTL-SDR device and still not happy, you can push things further. Stream1090 comes with a hacked version of the [RTL-SDR-BLOG](https://github.com/rtlsdrblog/rtl-sdr-blog) lib which in turn is a fork of librtlsdr. There are two aspects here.

--- a/configs/rtlsdr.ini
+++ b/configs/rtlsdr.ini
@@ -1,7 +1,7 @@
 # RTL-SDR configuration. The header entry defines
 # that this device uses librtlsdr. The values all
 # correspond to what rtl_sdr / rtl_test use. Key/value
-# pairs are processed in order as they appear in the file.
+# pairs are stored in a map and applied in alphabetical key order.
 [rtlsdr]
 
 # Optional: select a device by its exact serial string. If no exact match is
@@ -11,7 +11,14 @@
 # Center frequency in Hz (default: 1090 MHz for ADS-B)
 frequency = 1090000000
 
-# Gain in dB. If AGC is enabled, this value is ignored.
+# Gain in dB, applied to the tuner. Contrary to what this file used to say, it
+# is NOT ignored when agc is on. The two are separate stages on separate
+# chips: "agc" writes a demodulator register on the RTL2832 (digital AGC),
+# while "gain" goes over I2C to the tuner, so neither call undoes the other
+# whatever the order. They are not interchangeable either: measured on a
+# dongle with an external LNA in front, the digital AGC settles at 32 LSB RMS
+# with 2.19% of the samples clipped, while gain = 49.6 sits at 6.3 LSB RMS
+# with 0.03% clipped.
 # gain = 40
 agc = true
 
@@ -21,10 +28,41 @@ bias_tee = false
 # Optional: frequency correction in PPM
 # ppm = 0
 
-# Optional: tuner bandwidth in Hz (e.g. 3000000)
+# offset_tuning is NOT available on the R820T/R828D tuners used by every
+# common ADS-B dongle. The library repurposes that call to switch the bias tee
+# on, so asking for it would put 4.5 V on the antenna connector and then fail
+# anyway; it is rejected at startup. Use bias_tee above if that is what you
+# want.
+# offset_tuning = false
+
+# Optional: tuner bandwidth in Hz (e.g. 3000000). When unset, librtlsdr pins
+# the tuner IF filter to the sample rate, which is narrower than the ADS-B
+# pulse spectrum: rtlsdr_set_sample_rate() calls the tuner's set_bw() with
+# "dev->bw > 0 ? dev->bw : dev->rate". Widening it is worth measuring on your
+# own setup; narrowing it below the sample rate is not.
 # tuner_bandwidth = 3000000
 
 # Experimental LNA, MIXER, VGA controls via RTL-SDR-Blog fork.
+#
+# These are indices 0-15, not decibels, and they are an ALTERNATIVE to "gain",
+# never a refinement of it. All three must be set together: naming only one or
+# two leaves the remaining stages on hardware AGC, so the overall gain is not
+# what the written values suggest and drifts with the signal. That is rejected
+# at startup too.
+#
+# Setting both these and "gain" is rejected at startup: they drive the
+# same tuner in two different ways, and the per-stage keys would silently win
+# whatever the order in the file, because settings are applied in alphabetical
+# order rather than file order. They also require the vendored rtl-sdr-blog
+# fork (-DENABLE_RTLSDR_BLOG=ON); without it they are rejected too, since the
+# system librtlsdr has no such entry points.
+#
+# Note that "gain = 49.6" already asks for as much as the tuner will give.
+# r82xx_set_gain() walks the LNA and mixer step tables until it reaches the
+# requested figure, and 49.6 dB is where they top out, at LNA 15 / MIX 14,
+# with the VGA pinned to index 8. Mixer step 15 is negative (-0.8 dB), so
+# asking for MIX 15 by hand yields less total gain, not more.
+#
 # The table below shows the mapping between gain control values and LNA, MIX, VGA values.
 # So gain = 48.0 would correspond to setting 
 
@@ -63,6 +101,9 @@ bias_tee = false
 #      44.5 |  13 |  13 |  8  |
 #      48.0 |  14 |  13 |  8  |
 #      48.3 |  14 |  14 |  8  |
-#      48.8 |  15 |  15 |  8  |
+#      48.8 |  15 |  14 |  8  |
 #      49.6 |  15 |  14 |  8  |
-
+#
+# The 48.3 and 48.8 rows are not reachable through "gain": the R820T advertises
+# 29 gains and neither figure is among them, so both are snapped to the nearest
+# one that is, 48.0 and 49.6. 48.8 and 49.6 land on the same indices anyway.

--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -105,7 +105,8 @@ public:
         
         // tell the device to read all properties required to open it
         Log::info("Stream1090","Reading initial properties from the ini file");
-        m_device->applyConfigPreOpen(cfg);
+        if (!m_device->applyConfigPreOpen(cfg))
+            return false;
 
         
         // let us try to open the device
@@ -118,10 +119,7 @@ public:
 
         // device is ready, apply all the other properties
         Log::info("Stream1090","Device is open. Reading the ini file.");
-        m_device->applyConfigPostOpen(cfg);
-        
-        // we do not care if any of the properties did not work
-        return true;
+        return m_device->applyConfigPostOpen(cfg);
    }
 
     static constexpr auto constructMessageHandler(SampleStream<SamplerType>& sampleStream) {
@@ -203,10 +201,27 @@ public:
                     ProcessSignals::clearReload();
                     Log::info("Stream1090", "Re-reading config file.");
 
+                    const auto previousConfig = m_runtimeVars.deviceConfigSection;
                     if (reloadDeviceConfig()) {
-                        Log::info("Stream1090", "Applying new configuration.");
-                        m_device->applyConfigPostOpen(m_runtimeVars.deviceConfigSection);
+                        const auto& newConfig = m_runtimeVars.deviceConfigSection;
+                        if (!m_device->validateConfigPostOpen(newConfig)) {
+                            m_runtimeVars.deviceConfigSection = previousConfig;
+                            Log::warn("Stream1090", "Reloaded device configuration "
+                                      "is invalid. Keeping old settings.");
+                        } else {
+                            Log::info("Stream1090", "Applying new configuration.");
+                            if (!m_device->applyConfigPostOpen(newConfig)) {
+                                Log::error("Stream1090", "Hardware rejected a "
+                                           "validated setting. The device may be "
+                                           "partly configured; shutting down.");
+                                m_device->shutdownWriter();
+                                ProcessSignals::handle_sigint(0);
+                                intendedShutdown = false;
+                                break;
+                            }
+                        }
                     } else {
+                        m_runtimeVars.deviceConfigSection = previousConfig;
                         Log::warn("Stream1090", "Reload failed. Keeping old settings.");
                     }
                 }

--- a/include/devices/AirspyDevice.hpp
+++ b/include/devices/AirspyDevice.hpp
@@ -32,15 +32,17 @@ public:
     bool setBiasTee(bool enabled);
 
     // Called before opening the device to parse the serial
-    void applyConfigPreOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPreOpen(const IniConfig::Section& cfg) override;
 
     // Reload hook
-    void applyConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool validateConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPostOpen(const IniConfig::Section& cfg) override;
 
 private:
     bool open_with_serial(uint64_t serial);
     bool tryEnablingPacking();
-    bool applySetting(const std::string& key, const std::string& value);
+    bool applySetting(const std::string& key, const std::string& value) override;
+    bool validateSetting(const std::string& key, const std::string& value) const;
 
     struct ShadowState {
         uint32_t frequency = 1090000000;

--- a/include/devices/InputDeviceBase.hpp
+++ b/include/devices/InputDeviceBase.hpp
@@ -9,8 +9,61 @@
 #include "Sampler.hpp"
 #include "RingBuffer.hpp"
 #include "IniConfig.hpp"
+#include "Logger.hpp"
 #include <string>
 #include <atomic>
+#include <cstdint>
+#include <exception>
+
+namespace DeviceSettings {
+
+inline bool parseInt(const std::string& value, int& out) noexcept {
+    try {
+        std::size_t consumed = 0;
+        out = std::stoi(value, &consumed);
+        return consumed == value.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+inline bool parseUnsigned(const std::string& value, uint32_t& out) noexcept {
+    if (value.empty() || value.front() == '-')
+        return false;
+    try {
+        std::size_t consumed = 0;
+        const auto parsed = std::stoul(value, &consumed);
+        if (consumed != value.size() || parsed > UINT32_MAX)
+            return false;
+        out = static_cast<uint32_t>(parsed);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline bool parseFloat(const std::string& value, float& out) noexcept {
+    bool hasDigit = false;
+    for (const char ch : value) {
+        if (ch >= '0' && ch <= '9') {
+            hasDigit = true;
+            continue;
+        }
+        if (ch != '+' && ch != '-' && ch != '.' && ch != 'e' && ch != 'E')
+            return false;
+    }
+    if (!hasDigit)
+        return false;
+    try {
+        std::size_t consumed = 0;
+        out = std::stof(value, &consumed);
+        return consumed == value.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace DeviceSettings
 
 template<typename T>
 class InputDeviceBase {
@@ -32,13 +85,36 @@ public:
     virtual void close() = 0;
 
     // Called before open() is called to parse things like serial, packing etc.
-    virtual void applyConfigPreOpen(const IniConfig::Section&) {
+    virtual bool applyConfigPreOpen(const IniConfig::Section&) {
         // we do not do anything as default        
+        return true;
     };
 
+    virtual bool applySetting(const std::string& key, const std::string& value) = 0;
+
+    bool applySettingSafely(const std::string& key, const std::string& value) noexcept {
+        try {
+            return applySetting(key, value);
+        } catch (const std::exception& error) {
+            Log::error("InputDevice")
+                << "invalid value for setting '" << key << "': '" << value
+                << "' (" << error.what() << ")";
+        } catch (...) {
+            Log::error("InputDevice")
+                << "invalid value for setting '" << key << "': '" << value
+                << "'";
+        }
+        return false;
+    }
+
     // Called by the watchdog after SIGHUP
-    virtual void applyConfigPostOpen(const IniConfig::Section&) {
+    virtual bool validateConfigPostOpen(const IniConfig::Section&) {
+        return true;
+    }
+
+    virtual bool applyConfigPostOpen(const IniConfig::Section&) {
         // we do not do anything as default        
+        return true;
     };
 
     // Called by device callback threads

--- a/include/devices/RtlSdrDevice.hpp
+++ b/include/devices/RtlSdrDevice.hpp
@@ -34,15 +34,17 @@ public:
     bool setVgaGain(int value);
     
     // Called before opening the device to parse the serial
-    void applyConfigPreOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPreOpen(const IniConfig::Section& cfg) override;
 
     // Reload hook
-    void applyConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool validateConfigPostOpen(const IniConfig::Section& cfg) override;
+    bool applyConfigPostOpen(const IniConfig::Section& cfg) override;
     
 private:
     bool open_with_serial(uint64_t serial = 0);
     bool open_with_serial(const std::string& serial);
-    bool applySetting(const std::string& key, const std::string& value);
+    bool applySetting(const std::string& key, const std::string& value) override;
+    bool validateSetting(const std::string& key, const std::string& value) const;
 
     int nearestGain(int requested);
 
@@ -66,4 +68,3 @@ private:
     uint64_t m_actualSerial = 0;
     std::string m_serialString = "";
 };
-

--- a/include/devices/RtlSdrDevice.hpp
+++ b/include/devices/RtlSdrDevice.hpp
@@ -40,6 +40,14 @@ public:
     bool validateConfigPostOpen(const IniConfig::Section& cfg) override;
     bool applyConfigPostOpen(const IniConfig::Section& cfg) override;
     
+    // Reject the combinations the device would not apply in full. Static
+    // because it does not touch the device: it can run before opening it.
+    static bool validateCombinations(const IniConfig::Section& cfg);
+
+    // Checks that need to know which tuner is inside, so they can only run
+    // once the device is open.
+    bool validateAgainstTuner(const IniConfig::Section& cfg);
+
 private:
     bool open_with_serial(uint64_t serial = 0);
     bool open_with_serial(const std::string& serial);

--- a/src/devices/AirspyDevice.cpp
+++ b/src/devices/AirspyDevice.cpp
@@ -314,20 +314,31 @@ bool AirspyDevice::applySetting(const std::string& key, const std::string& value
     return false;
 }
 
+bool AirspyDevice::validateSetting(const std::string& key,
+                                  const std::string& value) const {
+    int integer = 0;
+    uint32_t frequency = 0;
+    if (key == "frequency")
+        return DeviceSettings::parseUnsigned(value, frequency);
+    if (key == "linearity_gain" || key == "sensitivity_gain"
+            || key == "lna_gain" || key == "mixer_gain" || key == "vga_gain")
+        return DeviceSettings::parseInt(value, integer);
+    return key == "bias_tee";
+}
 
-void AirspyDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
+
+bool AirspyDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
     for (auto& [key, value] : cfg) {
 
         if (key == "serial") {
             try {
                 std::size_t pos = 0;
                 uint64_t serial = std::stoull(value, &pos, 0);
-                if (pos != value.size()) {
-                    m_serial = 0;
-                }
+                if (pos != value.size())
+                    return false;
                 m_serial = serial;
             } catch (...) {
-                m_serial = 0;
+                return false;
             }   
         }
 
@@ -335,13 +346,29 @@ void AirspyDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
             m_packingEnabled = (value == "1" || value == "true" || value == "on");
         }
     }
+    return true;
 }
 
 
 // ----------------------
 // Reload logic
 // ----------------------
-void AirspyDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+bool AirspyDevice::validateConfigPostOpen(const IniConfig::Section& cfg) {
+    for (const auto& [key, value] : cfg) {
+        if (key == "serial" || key == "packing")
+            continue;
+        if (!validateSetting(key, value)) {
+            Log::error("AirspyDevice") << "invalid setting '" << key
+                                       << " = " << value << "'";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool AirspyDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+    if (!validateConfigPostOpen(cfg))
+        return false;
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
@@ -349,8 +376,8 @@ void AirspyDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
         if (key == "packing")
             continue; // immutable
 
-        applySetting(key, value);
+        if (!applySettingSafely(key, value))
+            return false;
     }
+    return true;
 }
-
-

--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -8,6 +8,7 @@
 #include "devices/RtlSdrSerial.hpp"
 #include "Logger.hpp"
 #include <iostream>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -421,7 +422,204 @@ bool RtlSdrDevice::validateSetting(const std::string& key,
 }
 
 
+// ----------------------
+// Configuration validation
+// ----------------------
+//
+// The rule: a configuration the device would not apply in full is an error,
+// not a warning. Whoever wrote it believes they are measuring one thing while
+// they are measuring another, and the wrong measurement is indistinguishable
+// from the right one.
+//
+// A note on ordering. Settings are applied by iterating over
+// IniConfig::Section, which is a std::map, so the order is ALPHABETICAL and
+// not the order of the file. "gain" therefore always comes before lna_gain,
+// mixer_gain and vga_gain, and the per-stage values overwrite the combined one
+// however the user wrote them. Measured on the bench: "gain = 49.6" on its own
+// leaves the signal at 5.88 LSB RMS; with "vga_gain = 0" next to it the signal
+// drops to 0.46, whichever of the two is written first.
+
+namespace {
+
+bool hasKey(const IniConfig::Section& cfg, const char* key) {
+    return cfg.find(key) != cfg.end();
+}
+
+std::string joinQuoted(const std::vector<std::string>& keys) {
+    std::string out;
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        if (i)
+            out += (i + 1 == keys.size()) ? " and " : ", ";
+        out += "'" + keys[i] + "'";
+    }
+    return out;
+}
+
+const char* verb(const std::vector<std::string>& keys, const char* one,
+                 const char* many) {
+    return keys.size() == 1 ? one : many;
+}
+
+constexpr const char* kPerStageKeys[] = { "lna_gain", "mixer_gain", "vga_gain" };
+
+} // namespace
+
+bool RtlSdrDevice::validateCombinations(const IniConfig::Section& cfg) {
+    std::vector<std::string> perStage;
+    for (const char* key : kPerStageKeys) {
+        if (hasKey(cfg, key))
+            perStage.push_back(key);
+    }
+
+    if (perStage.empty())
+        return true;
+
+    const std::string names = joinQuoted(perStage);
+
+#if !defined(STREAM1090_HAVE_RTLSDR_BLOG)
+    Log::error("RtlSdrDevice")
+        << "configuration rejected: " << names << " "
+        << verb(perStage, "requires", "require")
+        << " the vendored rtl-sdr-blog library, and this binary was built "
+           "without it.";
+    Log::error("RtlSdrDevice")
+        << "  The R820T per-stage gains do not exist in the system "
+           "librtlsdr, so nothing written here would ever reach the tuner.";
+    Log::error("RtlSdrDevice")
+        << "  Rebuild with -DENABLE_RTLSDR_BLOG=ON, or use 'gain = <dB>', "
+           "which goes through the standard gain table.";
+    return false;
+#else
+    if (hasKey(cfg, "gain")) {
+        Log::error("RtlSdrDevice")
+            << "configuration rejected: 'gain' cannot coexist with "
+            << names << ".";
+        Log::error("RtlSdrDevice")
+            << "  They are two alternative ways of driving the same tuner. "
+               "'gain' walks the R820T LNA and mixer step tables until it "
+               "reaches the requested figure and pins the VGA to index 8; the "
+               "per-stage keys write the three indices directly.";
+        Log::error("RtlSdrDevice")
+            << "  Used together the per-stage keys always win, silently, and "
+               "whatever their order in the file, because settings are "
+               "applied in alphabetical order.";
+        Log::error("RtlSdrDevice")
+            << "  Pick one of the two forms: 'gain = <dB>', or the three "
+               "per-stage indices.";
+        return false;
+    }
+
+    // The indices are 0-15 on all three stages: r82xx_set_lna_gain,
+    // r82xx_set_mixer_gain and r82xx_set_vga_gain_new reject anything else
+    // with -1, and without this check that reaches the user as a generic
+    // "Device configuration failed".
+    for (const char* key : kPerStageKeys) {
+        auto it = cfg.find(key);
+        if (it == cfg.end())
+            continue;
+
+        // The empty string has to be tested for on its own: std::stoi throws
+        // on it, and the "consumed != size" test below would then compare 0
+        // against 0 and let it through as if it were index 0.
+        int value = 0;
+        std::size_t consumed = 0;
+        try {
+            value = std::stoi(it->second, &consumed, 10);
+        } catch (...) {
+            consumed = 0;
+        }
+
+        if (it->second.empty() || consumed != it->second.size()
+                || value < 0 || value > 15) {
+            Log::error("RtlSdrDevice")
+                << "configuration rejected: '" << key << " = " << it->second
+                << "' is not a valid index.";
+            Log::error("RtlSdrDevice")
+                << "  The per-stage gains are integer indices from 0 to 15, "
+                   "not decibels: the value in dB is the one 'gain' takes.";
+            return false;
+        }
+    }
+
+    // All three or none. Naming only one leaves the other two on hardware AGC:
+    // the configuration is applied, but the overall gain is not the one the
+    // written values suggest, and it is not reproducible because two stages
+    // are chasing the signal on their own.
+    if (perStage.size() != std::size(kPerStageKeys)) {
+        std::vector<std::string> missing;
+        for (const char* key : kPerStageKeys) {
+            if (!hasKey(cfg, key))
+                missing.push_back(key);
+        }
+
+        Log::error("RtlSdrDevice")
+            << "configuration rejected: all three per-stage gains must be set, "
+               "and " << joinQuoted(missing) << " "
+            << verb(missing, "is", "are") << " missing here.";
+        Log::error("RtlSdrDevice")
+            << "  The stages that are not named stay on hardware AGC, so the "
+               "overall gain is not the one the written values suggest and it "
+               "drifts on its own with the signal.";
+        Log::error("RtlSdrDevice")
+            << "  Add the missing keys, or use 'gain = <dB>' to drive the "
+               "three stages together.";
+        return false;
+    }
+
+    return true;
+#endif
+}
+
+bool RtlSdrDevice::validateAgainstTuner(const IniConfig::Section& cfg) {
+    auto it = cfg.find("offset_tuning");
+    if (it == cfg.end())
+        return true;
+
+    const std::string& value = it->second;
+    if (!(value == "1" || value == "true" || value == "on"))
+        return true;
+
+    if (!m_dev)
+        return true;
+
+    const enum rtlsdr_tuner tuner = rtlsdr_get_tuner_type(m_dev);
+    if (tuner != RTLSDR_TUNER_R820T && tuner != RTLSDR_TUNER_R828D)
+        return true;
+
+    // On R820T/R828D rtlsdr_set_offset_tuning() does not do offset tuning. It
+    // returns -2 without tuning anything, so the key never had an effect on
+    // any dongle carrying one of these two tuners, which is all the common
+    // ADS-B ones.
+    Log::error("RtlSdrDevice")
+        << "configuration rejected: 'offset_tuning' is not supported by the "
+           "R820T/R828D tuner fitted to this dongle.";
+#if defined(STREAM1090_HAVE_RTLSDR_BLOG)
+    // The vendored rtl-sdr-blog fork goes further than returning -2: it
+    // deliberately reuses this call as a bias tee switch, for programs that
+    // have no dedicated command for one. Whoever writes offset_tuning = true
+    // against that library ends up with 4.5 V on the antenna cable and the
+    // program dead on the generic error that follows. Rejecting the key before
+    // it is applied is what keeps that from happening. The system librtlsdr
+    // does not have the shortcut, so this warning would be wrong there.
+    Log::error("RtlSdrDevice")
+        << "  The vendored rtl-sdr-blog library reuses that call to switch the "
+           "BIAS TEE on, that is to put 4.5 V on the antenna connector, and "
+           "then reports an error anyway.";
+#endif
+    Log::error("RtlSdrDevice")
+        << "  If you wanted the bias tee, ask for it explicitly with "
+           "'bias_tee = true'. If you wanted offset tuning, this tuner does "
+           "not have it: remove the key.";
+    return false;
+}
+
 bool RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
+    // Before touching the device: if the configuration is not applicable in
+    // full, failing now beats failing halfway through with the tuner already
+    // half reprogrammed.
+    if (!validateCombinations(cfg))
+        return false;
+
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
@@ -434,6 +632,16 @@ bool RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
 // Reload logic
 // ----------------------
 bool RtlSdrDevice::validateConfigPostOpen(const IniConfig::Section& cfg) {
+    // Repeated here because this is also the SIGHUP reload hook, which does
+    // not go through applyConfigPreOpen again.
+    if (!validateCombinations(cfg))
+        return false;
+
+    if (!validateAgainstTuner(cfg))
+        return false;
+
+    // Validate the complete reload before touching hardware. In particular,
+    // an invalid value late in the map cannot leave earlier keys half-applied.
     for (const auto& [key, value] : cfg) {
         if (key == "serial")
             continue;

--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -405,24 +405,57 @@ bool RtlSdrDevice::applySetting(const std::string& key, const std::string& value
     return false;
 }
 
+bool RtlSdrDevice::validateSetting(const std::string& key,
+                                  const std::string& value) const {
+    int integer = 0;
+    uint32_t unsignedValue = 0;
+    float gain = 0.0f;
+    if (key == "frequency" || key == "tuner_bandwidth")
+        return DeviceSettings::parseUnsigned(value, unsignedValue);
+    if (key == "gain")
+        return DeviceSettings::parseFloat(value, gain);
+    if (key == "ppm" || key == "lna_gain" || key == "mixer_gain"
+            || key == "vga_gain")
+        return DeviceSettings::parseInt(value, integer);
+    return key == "agc" || key == "bias_tee" || key == "offset_tuning";
+}
 
-void RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
+
+bool RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
             m_serialString = value;
     }
+    return true;
 }
 
 // ----------------------
 // Reload logic
 // ----------------------
-void RtlSdrDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+bool RtlSdrDevice::validateConfigPostOpen(const IniConfig::Section& cfg) {
+    for (const auto& [key, value] : cfg) {
+        if (key == "serial")
+            continue;
+        if (!validateSetting(key, value)) {
+            Log::error("RtlSdrDevice") << "invalid setting '" << key
+                                       << " = " << value << "'";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool RtlSdrDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+    if (!validateConfigPostOpen(cfg))
+        return false;
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")
             continue; // immutable
 
-        applySetting(key, value);
+        if (!applySettingSafely(key, value))
+            return false;
     }
+    return true;
 }

--- a/tests/DeviceConfigTest.cpp
+++ b/tests/DeviceConfigTest.cpp
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "devices/InputDeviceBase.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void requireImpl(bool condition, int line) {
+    if (!condition) {
+        std::fprintf(stderr, "requirement failed at line %d\n", line);
+        std::abort();
+    }
+}
+
+#define require(condition) requireImpl((condition), __LINE__)
+
+class NullWriter : public IAsyncWriter<int> {
+public:
+    size_t write(const int*, size_t n) override { return n; }
+    void shutdown() override {}
+};
+
+class TestDevice : public InputDeviceBase<int> {
+public:
+    explicit TestDevice(IAsyncWriter<int>& writer)
+        : InputDeviceBase<int>(Rate_1_0_Mhz, writer) {}
+
+    bool open() override { return true; }
+    bool start() override { return true; }
+    void stop() override {}
+    void close() override {}
+
+    bool applySetting(const std::string&, const std::string& value) override {
+        if (value == "invalid")
+            throw std::invalid_argument("invalid test value");
+        return value == "accepted";
+    }
+};
+
+} // namespace
+
+int main() {
+    NullWriter writer;
+    TestDevice device(writer);
+
+    require(device.applySettingSafely("gain", "accepted"));
+    require(!device.applySettingSafely("gain", "rejected"));
+    require(!device.applySettingSafely("gain", "invalid"));
+
+    int integer = 0;
+    uint32_t unsignedValue = 0;
+    float floating = 0.0f;
+    require(DeviceSettings::parseInt("-12", integer) && integer == -12);
+    require(!DeviceSettings::parseInt("", integer));
+    require(!DeviceSettings::parseInt("12dB", integer));
+    require(!DeviceSettings::parseInt("99999999999999999999", integer));
+    require(DeviceSettings::parseUnsigned("1090000000", unsignedValue)
+            && unsignedValue == 1090000000);
+    require(!DeviceSettings::parseUnsigned("", unsignedValue));
+    require(!DeviceSettings::parseUnsigned("-1", unsignedValue));
+    require(!DeviceSettings::parseUnsigned("4294967296", unsignedValue));
+    require(DeviceSettings::parseFloat("49.6", floating)
+            && floating == 49.6f);
+    require(DeviceSettings::parseFloat("1e2", floating)
+            && floating == 100.0f);
+    require(!DeviceSettings::parseFloat("", floating));
+    require(!DeviceSettings::parseFloat("49.6dB", floating));
+    require(!DeviceSettings::parseFloat("nan", floating));
+    require(!DeviceSettings::parseFloat("inf", floating));
+}

--- a/tests/RtlSdrConfigValidationTest.cpp
+++ b/tests/RtlSdrConfigValidationTest.cpp
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Combinations the device would not apply in full must be rejected. The case
+// that motivated the check: 'gain' and the per-stage gains drive the same
+// tuner in two alternative ways, and used together the per-stage ones always
+// win, silently and whatever their order in the file, because
+// IniConfig::Section is a std::map and settings are applied in alphabetical
+// order.
+
+#include "devices/RtlSdrDevice.hpp"
+
+#include <cstdlib>
+#include <cstdio>
+
+namespace {
+
+int failures = 0;
+
+void check(const char* what, bool got, bool want) {
+    if (got != want) {
+        std::printf("FAIL %s: expected %s, got %s\n", what,
+                    want ? "accepted" : "rejected",
+                    got ? "accepted" : "rejected");
+        failures++;
+    }
+}
+
+IniConfig::Section section(std::initializer_list<std::pair<const char*, const char*>> kv) {
+    IniConfig::Section s{{"serial", "00000001"}, {"frequency", "1090000000"}};
+    for (auto& [k, v] : kv)
+        s[k] = v;
+    return s;
+}
+
+bool validate(const IniConfig::Section& s) {
+    return RtlSdrDevice::validateCombinations(s);
+}
+
+} // namespace
+
+int main() {
+    // Valid forms: one of the two, never both.
+    check("frequency and serial only", validate(section({})), true);
+    check("gain only", validate(section({{"gain", "49.6"}})), true);
+    check("gain with agc", validate(section({{"gain", "49.6"}, {"agc", "true"}})), true);
+
+#if defined(STREAM1090_HAVE_RTLSDR_BLOG)
+    check("three per-stage indices",
+          validate(section({{"lna_gain", "15"}, {"mixer_gain", "15"}, {"vga_gain", "8"}})), true);
+    check("three indices at the ends of the range",
+          validate(section({{"lna_gain", "0"}, {"mixer_gain", "15"}, {"vga_gain", "0"}})), true);
+
+    // All three or none: naming only some of them leaves the other stages on
+    // hardware AGC, so the overall gain is not the one the written values
+    // suggest.
+    check("lna_gain only", validate(section({{"lna_gain", "15"}})), false);
+    check("mixer_gain only", validate(section({{"mixer_gain", "15"}})), false);
+    check("vga_gain only", validate(section({{"vga_gain", "8"}})), false);
+    check("two out of three",
+          validate(section({{"lna_gain", "15"}, {"vga_gain", "8"}})), false);
+
+    // The conflict, with each of the three stages.
+    check("gain + lna_gain",
+          validate(section({{"gain", "49.6"}, {"lna_gain", "15"}})), false);
+    check("gain + mixer_gain",
+          validate(section({{"gain", "49.6"}, {"mixer_gain", "15"}})), false);
+    check("gain + vga_gain",
+          validate(section({{"gain", "49.6"}, {"vga_gain", "8"}})), false);
+    check("gain + all three",
+          validate(section({{"gain", "49.6"}, {"lna_gain", "15"},
+                            {"mixer_gain", "15"}, {"vga_gain", "8"}})), false);
+
+    // Out of range indices. 335 is the value one gets by reading the commented
+    // out, tenths-of-a-dB version of r82xx_set_lna_gain: the live function
+    // takes indices 0-15 and returns -1 for everything else.
+    // Complete triples with a single invalid value, so that the rejection is
+    // attributable to the range and not to an incomplete triple.
+    auto triple = [](const char* l, const char* m, const char* v) {
+        return section({{"lna_gain", l}, {"mixer_gain", m}, {"vga_gain", v}});
+    };
+    check("lna_gain = 335", validate(triple("335", "15", "8")), false);
+    check("vga_gain = 16", validate(triple("15", "15", "16")), false);
+    check("negative mixer_gain", validate(triple("15", "-1", "8")), false);
+    check("non numeric index", validate(triple("15", "15", "high")), false);
+    check("index with trailing text", validate(triple("15", "15", "8dB")), false);
+    // "vga_gain =" with nothing after it. std::stoi throws on the empty
+    // string, so the range test alone would compare 0 consumed characters
+    // against a length of 0 and take it for a valid index 0.
+    check("empty index", validate(triple("15", "15", "")), false);
+    check("whitespace index", validate(triple("15", "15", " ")), false);
+#else
+    // Without the vendored library the three stages do not exist: they must
+    // always be rejected, or the user believes they have set them.
+    check("per-stage without the blog fork", validate(section({{"lna_gain", "15"}})), false);
+    check("per-stage without the blog fork, valid value",
+          validate(section({{"vga_gain", "8"}})), false);
+#endif
+
+    if (failures) {
+        std::printf("%d tests failed\n", failures);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
> Stacked on #58 — it needs the `bool` config hooks introduced there, so the diff shown here includes that commit until #58 merges. Review the second commit only.

More than one RTL-SDR configuration was accepted and then applied only in part, or not applied at all, with no way for the user to notice. A measurement taken with one of those is indistinguishable from a measurement taken with the configuration the user believes they set.

## The five cases now rejected

**`gain` together with `lna_gain` / `mixer_gain` / `vga_gain`.** Two alternative ways of driving the same tuner. The per-stage keys always win, because `IniConfig::Section` is a `std::map` and settings are applied in alphabetical order rather than file order: `gain` always arrives first and is overwritten. Measured on the bench, `gain = 49.6` on its own leaves the signal at 5.88 LSB RMS; with `vga_gain = 0` next to it the signal drops to 0.46, whichever of the two is written first in the file.

**Per-stage gains without the vendored rtl-sdr-blog fork.** Those entry points do not exist in the system librtlsdr, so a binary built with `-DENABLE_RTLSDR_BLOG=OFF` accepted the keys and did nothing with them.

**Per-stage gains named only in part.** Setting `lna_gain` without the other two leaves mixer and VGA on hardware AGC. The configuration is applied, but the overall gain is not the one the written values suggest and it is not reproducible, because two stages are chasing the signal on their own. All three or none.

**Per-stage indices outside 0-15.** `r82xx_set_lna_gain`, `r82xx_set_mixer_gain` and `r82xx_set_vga_gain_new` return `-1` for anything else, and that reached the user as a generic "Device configuration failed". The value 335 is not a random example: it is what one gets by reading the tenths-of-a-dB version of those functions, which is the copy inside the commented out block of `tuner_r82xx.c`.

**`offset_tuning = true` on R820T/R828D.** `rtlsdr_set_offset_tuning()` returns `-2` on those tuners without tuning anything, so the key never had an effect on any of the dongles people actually use for ADS-B. Against the **vendored rtl-sdr-blog fork** the damage goes further than silence: that fork deliberately reuses the call as a bias tee switch (`rtlsdr_set_bias_tee(dev, on); return -2;`), so whoever wrote the key ended up with 4.5 V on the antenna connector and the program dead on the generic error that follows. The rejection happens before the key is applied, so that no longer happens. The extra warning about the bias tee is compiled in only where the fork is — the system librtlsdr (osmocom/steve-m) just does `return -2;`, and the warning would be wrong there.

## Where the checks run

`validateCombinations()` needs no device, so it runs in `applyConfigPreOpen()` — before the dongle is opened — and again in `validateConfigPostOpen()`, before the SIGHUP reload hook applies any setting. `validateAgainstTuner()` has to ask which tuner is inside, so it can only run once the device is open.

## `configs/rtlsdr.ini`

Same explanations, plus a correction: the file said that `gain` is ignored when the AGC is on. That is not true, and the code settles it without needing a bench. `setAgc()` calls `rtlsdr_set_agc_mode()`, which writes a demodulator register on the RTL2832 (`rtlsdr_demod_write_reg(dev, 0, 0x19, ...)`); `setGain()` calls `rtlsdr_set_tuner_gain_mode()` and `rtlsdr_set_tuner_gain()`, which go over I2C to the tuner. Separate stages on separate chips, and neither call undoes the other whatever the order they are applied in.

They are not interchangeable either: with an external LNA in front, the digital AGC settles at 32 LSB RMS with 2.19% of the samples clipped, while `gain = 49.6` sits at 6.3 LSB RMS with 0.03% clipped.

## Two corrections to the gain table already in the file

The `48.8` row read LNA 15 / MIX 15, where `r82xx_set_gain()` walking the step tables gives LNA 15 / MIX 14. And neither `48.3` nor `48.8` is among the 29 gains the R820T advertises through `rtlsdr_get_tuner_gains()`, so `nearestGain()` snaps both to a neighbour rather than applying them.

Worth noting for anyone reaching for the per-stage keys to get past `gain = 49.6`: that figure is already the top of the walk. Mixer step 15 is `-8` tenths of a dB, so taking it would *lower* the total from 496 to 488.

## Testing

`tests/RtlSdrConfigValidationTest.cpp`, no hardware needed, covering both the vendored-fork and the system-librtlsdr branch. It compiles the device, so it is only registered where the RTL-SDR backend was built.

Rebased onto current `main` through #58. Full suite green on macOS/arm64 with both the system and vendored RTL-SDR backends: 12/12. Compiles clean under `-Wall -Wextra -Wunused-function -Werror` with and without `STREAM1090_HAVE_RTLSDR_BLOG`.

Two of the test cases are there for a hole worth naming: `std::stoi` throws on the empty string, which leaves the count of consumed characters at zero, and comparing that against a length of zero would take `vga_gain =` for a valid index 0. Removing the guard makes the suite fail on exactly that case.

Coverage now includes both branches in CI: #61 added the `-DENABLE_RTLSDR_BLOG=ON` job, while the standard jobs exercise system librtlsdr.

## Relation to the other RTL-SDR PRs

Stacked on #58 and rebased after #61, #57 and #56 merged. The serial lookup from #56 and both configuration-test targets are retained.
