### PR TITLE
CI: build on macOS with Apple Clang and warnings fatal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,30 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+  # macOS with Apple Clang, and warnings fatal. Two things nothing else covers:
+  # Apple Clang is a different compiler from the gcc and Clang the Ubuntu jobs
+  # run, with a different warning set and a different standard library, and no
+  # job builds on macOS at all. -Werror is set here rather than in
+  # CMakeLists.txt so a warning fails the pipeline without failing the build
+  # for anyone compiling by hand.
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install pkg-config libusb airspy librtlsdr
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_TESTING=ON
+          -DCMAKE_CXX_FLAGS=-Werror
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -76,7 +76,7 @@ public:
 
 	/// True when the preamble in front of this candidate is strong enough to be
 	/// a real transmission. Disabled unless STREAM1090_PREAMBLE_GATE is defined.
-	bool preambleConfirms(int streamIndex) noexcept {
+	bool preambleConfirms([[maybe_unused]] int streamIndex) noexcept {
 	#if defined(STREAM1090_PREAMBLE_GATE) && STREAM1090_PREAMBLE_GATE
 		if (m_preambleFn == nullptr)
 			return false;


### PR DESCRIPTION
> Stacked on #53 — the job cannot be green without it, so the diff shown here includes that one-line commit. Review the second commit only.

Two gaps this closes. **Apple Clang is not the Clang the Ubuntu job runs**: a different front end over a different standard library, with its own warning set. And **nothing in this workflow builds on macOS at all**, although the project is developed on it.

## Why -Werror is on the command line

It goes in the workflow rather than into `DEFAULT_COMPILE_OPTIONS` in `CMakeLists.txt` on purpose. A warning should fail the pipeline; it should not fail the build for someone compiling the same tree by hand, on a compiler version whose warnings we have not seen.

## Why #53 has to come first

The whole tree compiles clean under `-Wall -Wextra -Wunused-function -Werror` **except** the unused `streamIndex` parameter in `DemodCore.hpp:79`, which is exactly what #53 marks `maybe_unused`. Verified both ways on macOS 15 with Apple Clang:

| tree | result |
|---|---|
| `main` + this job | `error: unused parameter 'streamIndex' [-Werror,-Wunused-parameter]` |
| `main` + #53 + this job | clean build, suite passes |

That single warning is the only one in the entire build, so nothing else stands between the project and warnings-fatal CI.

Merges cleanly with #61 (the vendored-fork job); the two add different jobs to the same file at different points.
