### PR TITLE
suspicious.py: fail loudly when pyModeS is too old

### DIFF
--- a/other_utils/suspicious.py
+++ b/other_utils/suspicious.py
@@ -3,6 +3,14 @@
 import sys
 import pyModeS as pms
 
+# pms.decode() arrived in pyModeS 3. On an older one every call below raises,
+# the except swallows it, and the script ends with '0 suspicious out of 0' --
+# which reads exactly like a clean stream. Say what is missing instead.
+if not hasattr(pms, "decode"):
+    sys.exit(
+        "suspicious.py needs pyModeS 3 or newer: this one has no pms.decode(). "
+        "Installed version: %s" % getattr(pms, "__version__", "unknown"))
+
 # Track ICAO appearances
 icao_seen = set()
 icao_df17_seen = set()
@@ -292,6 +300,7 @@ def parse_stream1090_line(line: str):
 
 total_messages = 0
 suspicious_messages = 0
+undecodable = 0
 
 for raw in sys.stdin:
     parsed = parse_stream1090_line(raw)
@@ -303,9 +312,11 @@ for raw in sys.stdin:
     try:
         decoded = pms.decode(frame_hex)
     except Exception:
+        undecodable = undecodable + 1
         continue
 
     if decoded is None:
+        undecodable = undecodable + 1
         continue
 
     df = decoded["df"]
@@ -331,3 +342,8 @@ for raw in sys.stdin:
     
     
 print(f"{suspicious_messages} suspicious out of {total_messages}")
+if undecodable:
+    # Not necessarily a problem -- a stream full of fabricated frames has
+    # plenty that decode to nothing -- but a run where everything was skipped
+    # is a broken run, not a clean stream, and the two used to look identical.
+    print(f"{undecodable} messages could not be decoded and were skipped")


### PR DESCRIPTION
## Summary

- stop immediately with a clear error when the installed pyModeS has no top-level decode API
- report how many otherwise valid input messages could not be decoded

## Why

The top-level pyModeS.decode API was introduced in pyModeS 3. With pyModeS 2, every call raises AttributeError; the broad per-message exception handler currently swallows that error and the script finishes with:

    0 suspicious out of 0

That is indistinguishable from a clean stream even though no frame was decoded.

The capability check targets the API the script actually needs and reports the installed version when available. Individual frames may still legitimately fail to decode, so those remain non-fatal but are now counted in the final output.

## Testing

Using seven frames emitted by stream1090 from a pure-white-noise input:

- pyModeS 2.22 before this change: 0 suspicious out of 0
- pyModeS 2.22 after this change: exits with a clear pyModeS 3 requirement
- pyModeS 3.6.0 after this change: 4 suspicious out of 7

The branch also passes Python syntax compilation and git diff --check.