### PR TITLE
DemodCore: trust a new address on a second sighting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,12 @@ if(BUILD_TESTING)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
     stream1090_add_test(rtlsdr_serial_test tests/RtlSdrSerialTest.cpp)
+    stream1090_add_test(noise_false_positive_test tests/NoiseFalsePositiveTest.cpp)
+    target_compile_definitions(noise_false_positive_test PRIVATE
+        ${PREAMBLE_GATE_DEF}
+        ${PREAMBLE_THRESHOLD_DEF}
+        ${MIN_SNR_DEF}
+    )
 endif()
 
 # ------------------------------------------------------------

--- a/include/BlockRing.hpp
+++ b/include/BlockRing.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstring>
 #include <memory>
 #include <algorithm>
 

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -298,8 +298,26 @@ public:
 				// and send the 112 bit message to the output
 				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 			} else {
-				m_cache.markAsTrustedSeen(m_cache.insertWithCA(icaoWithCA));
-			} 
+				// This is the only door into the trusted set. The first
+				// sighting of a new address enters it untrusted: the parity
+				// routes see it (their own noise-floor gates still apply),
+				// but the error table repair, the erasure repair and the DF11
+				// parity overwrite wait for trust. Trust arrives with the
+				// second sighting, through the known branch above. Noise
+				// clears 24 bits of CRC often enough to invent an address
+				// every four seconds, but it never repeats the same random
+				// address, so the second sighting is where noise dies.
+				const bool confirmed = m_cache.confirmTrustCandidate(icaoWithCA);
+				const auto it = m_cache.insertWithCA(icaoWithCA);
+				if (confirmed) {
+					// the entry had expired since the first sighting, so the
+					// second sighting does not reach the known branch
+					m_cache.markAsTrustedSeen(it);
+					return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, it);
+				}
+				m_cache.markAsSeen(it);
+				return false;
+			}
 		} else {
 			// the crc is not zero, so we might have a broken message
 			logStats(Stats::DF17_BAD_MESSAGE);
@@ -509,9 +527,25 @@ public:
 		if (crc == 0) {
 			// A 24-bit CRC passes on noise about once per 16M candidate windows,
 			// and each such DF11 inserts an address that then licenses
-			// address-parity frames of its own. Reject the noise-floor,
-			// preamble-less ones to break that loop.
-			if (signalAtNoiseFloor(streamIndex) && !preambleConfirms(streamIndex)) {
+			// address-parity frames of its own. A new address gets in untrusted
+			// on the first sighting and becomes trusted on the second, like the
+			// DF17 door: noise never repeats a random address, an aircraft
+			// repeats all the time.
+			const auto icaoWithCA = ModeS::extractICAOWithCA_Short(frameShort);
+			if (!m_cache.findWithCA(icaoWithCA).isValid()) {
+				if (m_cache.confirmTrustCandidate(icaoWithCA)) {
+					// second sighting within the window: trusted, and emitted
+					const auto it = m_cache.insertWithCA(icaoWithCA);
+					m_cache.markAsTrustedSeen(it);
+					logStats(Stats::DF11_ICAO_CA_FOUND_GOOD_CRC);
+					return handleDF11ShortMessageWithZeroCRC(streamIndex, frameShort, false);
+				}
+				// first sighting: enter untrusted so the parity routes see the
+				// address, but emit nothing and leave the repairs locked
+				if (!m_cache.find(icaoWithCA & 0xFFFFFF).isValid()) {
+					const auto it = m_cache.insertWithCA(icaoWithCA);
+					m_cache.markAsSeen(it);
+				}
 				return false;
 			}
 			logStats(Stats::DF11_ICAO_CA_FOUND_GOOD_CRC);

--- a/include/ICAOCache.hpp
+++ b/include/ICAOCache.hpp
@@ -154,6 +154,33 @@ public:
 		return false;
 	}
 
+	// The trust door asks a new address for a second sighting instead of
+	// noise-floor evidence. A transponder squitters at 2 Hz, so two sightings
+	// of the same address within thirty seconds are routine; noise clearing
+	// 24 parity bits twice on the same random address is not. The window
+	// matches the trust TTL, and sparse emitters (TIS-B at a fraction of a
+	// hertz) still make the pair. A persistently weak aircraft opens the
+	// door on its second squitter, and stays in.
+	static constexpr uint32_t TrustCandidateMinTicks { 100 };
+	static constexpr uint32_t TrustCandidateMaxTicks { 30'000'000 };
+
+	bool confirmTrustCandidate(uint32_t icaoWithCA) noexcept {
+		auto& candidate = m_trustCandidates[trustCandidateIndex(icaoWithCA)];
+		const auto age = m_df11Clock - candidate.firstSeen;
+
+		if (candidate.icaoWithCA != 0 && candidate.icaoWithCA == icaoWithCA) {
+			if (age >= TrustCandidateMinTicks && age <= TrustCandidateMaxTicks) {
+				candidate = TrustCandidate{};
+				return true;
+			}
+			if (age < TrustCandidateMinTicks)
+				return false;
+		}
+
+		candidate = TrustCandidate{icaoWithCA, m_df11Clock};
+		return false;
+	}
+
 	bool confirmRejectedShort(uint32_t icao, uint64_t frame) noexcept {
 		return confirmRejectedFrame(icao, 0, frame, 56);
 	}
@@ -302,8 +329,17 @@ private:
 		uint64_t firstSeen { 0 };
 	};
 
+	struct TrustCandidate {
+		uint32_t icaoWithCA { 0 };
+		uint64_t firstSeen { 0 };
+	};
+
 	static constexpr size_t df11CandidateIndex(uint32_t icaoWithCA) noexcept {
 		return (icaoWithCA * 0x9e3779b1u) >> 24;
+	}
+
+	static constexpr size_t trustCandidateIndex(uint32_t icaoWithCA) noexcept {
+		return (icaoWithCA * 0x9e3779b1u) >> 23;
 	}
 
 	void setTrustedBit(uint32_t key) noexcept {
@@ -369,6 +405,7 @@ private:
 	uint32_t m_time1Mhz { 0 };
 	uint64_t m_df11Clock { 0 };
 	std::array<DF11Candidate, 256> m_df11Candidates{};
+	std::array<TrustCandidate, 512> m_trustCandidates{};
 	std::array<RejectedFrameCandidate, RejectedCandidateCount> m_rejectedCandidates{};
 
     // the table with the icao addresses including transponder CA 

--- a/tests/NoiseFalsePositiveTest.cpp
+++ b/tests/NoiseFalsePositiveTest.cpp
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "InputReaderBase.hpp"
+#include "RawInputFormat.hpp"
+#include "SampleStream.hpp"
+#include "Sampler.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+using Sampler = Sampler_10_0_to_48_0_Mhz;
+
+struct NoiseCase {
+  uint64_t offset;
+  uint64_t positions;
+};
+
+// Each window starts 10 ms before the minimum pre-roll found by bisection and
+// ends 10 ms after the known emission. Any frame emitted from pure noise fails
+// the regression.
+constexpr std::array<NoiseCase, 10> NoiseCases{{
+    {385'046'780, 50'081'218},
+    {385'046'635, 96'395'025},
+    {962'286'190, 74'498'908},
+    {1'109'091'320, 201'712},
+    {1'188'570'535, 14'440'447},
+    {1'217'535'165, 9'692'870},
+    {1'278'588'175, 34'295'945},
+    {1'318'201'410, 40'561'015},
+    {1'443'420'445, 5'709'182},
+    {1'713'099'945, 32'210'831},
+}};
+
+struct EmittedFrame {
+  bool isLong;
+  uint64_t high;
+  uint64_t low;
+};
+
+struct CountingHandler {
+  explicit CountingHandler(std::vector<EmittedFrame> &uniqueFrames)
+      : m_uniqueFrames(uniqueFrames) {}
+
+  void handleShort(uint64_t, uint64_t frame) {
+    ++frameCount;
+    logFrame({false, 0, frame});
+  }
+
+  void handleLong(uint64_t, const Bits128 &frame) {
+    ++frameCount;
+    logFrame({true, frame.high() & 0xffffffffffffull, frame.low()});
+  }
+
+  uint64_t frameCount{0};
+
+private:
+  void logFrame(const EmittedFrame &frame) {
+    const auto seen = std::find_if(
+        m_uniqueFrames.begin(), m_uniqueFrames.end(), [&](const auto &other) {
+          return other.isLong == frame.isLong && other.high == frame.high &&
+                 other.low == frame.low;
+        });
+    if (seen != m_uniqueFrames.end())
+      return;
+
+    m_uniqueFrames.push_back(frame);
+    std::printf("forbidden frame: ");
+    if (frame.isLong) {
+      std::printf("%012llX%016llX", static_cast<unsigned long long>(frame.high),
+                  static_cast<unsigned long long>(frame.low));
+    } else {
+      std::printf("%014llX", static_cast<unsigned long long>(frame.low));
+    }
+    std::printf("\n");
+  }
+
+  std::vector<EmittedFrame> &m_uniqueFrames;
+};
+
+// SplitMix64 makes every sample a pure function of its absolute index. This
+// lets each test seek directly to a known failure without generating the long
+// prefix before it. The low five bits give uniform white noise centred on the
+// Airspy midpoint, at about -47 dBFS RMS.
+uint64_t noiseWord(uint64_t index) noexcept {
+  uint64_t x = index + 0x9E3779B97F4A7C15ull;
+  x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+  x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+  return x ^ (x >> 31);
+}
+
+struct NoPipeline {
+  static constexpr bool isEmpty = true;
+};
+
+class NoiseReader
+    : public InputReaderBase<IQ_UINT16_RAW_AIRSPY, Sampler::InputBufferSize,
+                             NoPipeline> {
+public:
+  NoiseReader(NoPipeline &pipeline, uint64_t offset, uint64_t positions)
+      : InputReaderBase<IQ_UINT16_RAW_AIRSPY, Sampler::InputBufferSize,
+                        NoPipeline>(pipeline),
+        m_offset(offset), m_remaining(positions) {}
+
+  void readMagnitude(int32_t *out) noexcept {
+    const size_t count =
+        std::min<uint64_t>(m_remaining, Sampler::InputBufferSize);
+    for (size_t i = 0; i < count; ++i) {
+      for (size_t lane = 0; lane < 2; ++lane) {
+        const uint64_t rawIndex = 2 * (m_offset + i) + lane;
+        const int delta = int(noiseWord(rawIndex) & 31u) - 16;
+        m_raw[2 * i + lane] = uint16_t(2048 + delta);
+      }
+    }
+
+    // Match InputStdStreamReader: a short final block is zero-padded in the
+    // raw unsigned format before it is converted to magnitude.
+    std::fill(m_raw.begin() + 2 * count, m_raw.end(), uint16_t(0));
+    this->processBlock(m_raw.data(), out);
+    m_offset += count;
+    m_remaining -= count;
+  }
+
+  bool eof() const noexcept { return m_remaining == 0; }
+
+private:
+  uint64_t m_offset;
+  uint64_t m_remaining;
+  std::array<uint16_t, 2 * Sampler::InputBufferSize> m_raw{};
+};
+
+} // namespace
+
+int main() {
+  size_t failedCases = 0;
+  std::vector<EmittedFrame> uniqueFrames;
+
+  for (size_t i = 0; i < NoiseCases.size(); ++i) {
+    const auto &test = NoiseCases[i];
+    NoPipeline pipeline;
+    NoiseReader reader(pipeline, test.offset, test.positions);
+    CountingHandler handler(uniqueFrames);
+    SampleStream<Sampler> stream;
+    stream.read(reader, handler);
+
+    if (handler.frameCount == 0)
+      continue;
+
+    ++failedCases;
+    std::printf("FAILED case %zu: pure noise emitted %llu frame%s\n", i + 1,
+                static_cast<unsigned long long>(handler.frameCount),
+                handler.frameCount == 1 ? "" : "s");
+  }
+
+  if (failedCases == 0)
+    return 0;
+
+  std::printf(
+      "FAILED: %zu of %zu pure-noise windows emitted %zu distinct frames\n",
+      failedCases, NoiseCases.size(), uniqueFrames.size());
+  return 1;
+}


### PR DESCRIPTION
# DemodCore: trust a new address on a second sighting

The first commit is the white-noise regression from #65; the second is
the change that makes it pass.

## The problem

A clean extended squitter whose address is unknown is the only door into
the trusted set, and a zero CRC was the whole of the evidence it asked
for. Noise clears 24 bits of CRC often enough to invent an address every
four seconds, and each invented address stays trusted for the next
thirty. Nothing is emitted at the door itself, but a trusted address is
what licenses the error table repair, the erasure repair and the DF11
parity overwrite — none of which check the CRC again. Over 500 seconds
of pure noise, 129 invented addresses let 15 frames out by those three
routes.

## Why signal strength was the wrong evidence

The obvious fix — require the frame that opens the door to sit above the
local noise floor or to have a preamble — does not work. The SNR
estimate is a peak over a percentile, and that ratio has a heavy tail:
pure noise exceeds it often enough that **all ten recorded windows of
the #65 regression still failed** with such a gate in place (this was
measured: the ctest stayed red). The ratio also punishes exactly the
frames that matter most — a busy channel lifts the percentile, and a
fringe aircraft lives below any fixed threshold forever, losing its
repair-routed messages every time it is re-gated.

## The change

The evidence that actually separates noise from aircraft is repetition:
a transponder squitters at 2 Hz, while noise invents a fresh random
address every four seconds and never repeats one — two sightings of the
same 24-bit address within the window have probability zero for noise.

So the door now works like the DF11 interrogator-code path already does
(`confirmDF11Candidate`):

- **First sighting** of a new address enters it *untrusted*: the
  address-parity routes see it (their existing noise-floor gates still
  apply), but all three repairs stay locked. Nothing is emitted.
- **Second sighting within 30 s** (the trust TTL) marks it trusted, and
  the confirming sighting is emitted like any other frame.
- The DF0/4/5 and DF16/20/21 address-parity routes keep their existing
  noise-floor gates unchanged.

Diff: 77 insertions, 6 deletions across `ICAOCache.hpp` (a 512-entry
candidate table mirroring `m_df11Candidates`) and `DemodCore.hpp` (the
door and the DF11 CRC=0 site).

## Measurements

End-to-end: deterministic SplitMix64 white noise (same generator as the
#65 test) piped through the full binary, 500 s per run.

| scenario | main | this branch |
|---|---|---|
| noise, 2.4→12 Msps, 500 s | 9 invented frames | **0** |
| noise, 10→24 Msps, 500 s | 1 invented frame | **0** |
| noise, 10→48 Msps (production), 500 s | 18 invented frames | **0** |
| #65 regression test (ten windows) | red | **green** |
| full ctest suite | — | **11/11** |

Five real captures (community recordings, ~690k messages, ~6 minutes of
airtime), FIR + upsampling at maximum:

| capture | main | this branch |
|---|---|---|
| sawbird_256_3 | 39 666 | 39 739 |
| jim_merk_samples_256 | 480 870 | 481 469 |
| rhodan_samples_6M | 31 053 | 31 018 |
| halde_6M_1 | 75 317 | 75 527 |
| halde_10M_0 | 63 429 | 63 568 |
| **total** | **690 435** | **691 321 (+886)** |

The branch emits *more* than main because main's noise-floor gate on
DF11 refuses to cache weak addresses at all, so their subsequent frames
never reach the output. All 88 unique extra messages were verified
genuine: addresses already tracked, positions decoding onto the
aircraft's track (0.0–15 km), velocities matching its own trend, and the
remaining "new" addresses each backed by two independent CRC-valid
demodulations of the same address — which noise does not do.

The only cost: addresses seen exactly once in a capture shorter than the
window cannot make the pair — 35 messages in a 21 second recording
(rhodan, −0.005%).

## Open questions for review

1. **Address 000000**: a pair of CRC-valid sightings now trusts it. It
   is a real emitter (bad equipment/test transponder) but invalid as an
   aircraft address — reject it upstream of the door?
2. **Candidate table**: 512 entries, same hash-multiply-index scheme as
   `m_df11Candidates`. A collision only delays trust by one window; no
   correctness impact.
3. **Window**: 30 s chosen to match the trust TTL, minimum separation
   100 µs identical to the DF11 candidate path. Sparse emitters (TIS-B
   at a fraction of a Hz) still make the pair.
4. This is deliberately small ahead of the proposed DemodCore
   restructuring; the trust door is one of the spots that wants a
   cleaner shape afterwards.

## Reproducing

```
ctest                                       # 11/11, incl. the noise regression
cat noise.bin | ./stream1090 -s 10 -u 48    # 0 frames from 500 s of pure noise
cat capture.raw | ./stream1090 -s 2.56 -u 12 -q   # per-capture counts above
```
