### PR TITLE
Pin R820T tuner bandwidth in the default RTL-SDR config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Edit the corresponding file for your device and read the comments. For now you m
 
 **Important:** If you are powering an LNA via bias-tee, you have to turn that on by setting ```bias_tee = true```. It is off by default.
 
+For common R820T/R820T2 receivers, the supplied `rtlsdr.ini` pins
+`tuner_bandwidth` to 3 MHz. At the commonly used 2.4 and 2.56 Msps sample rates,
+librtlsdr maps this request to the 6 MHz IF filter state. Setting it explicitly
+keeps the tuner state consistent across librtlsdr implementations. Stream1090
+warns at startup when the setting is missing on these tuners. Other tuner types
+or sample rates may need a different value.
+
 ### Minimal running example
 For the sake of a first try, we will focus only on parameters that are necessary to get things up and running. You may have noticed that the sample rate is not part of the ini file. There are reasons for that. 
 

--- a/configs/rtlsdr.ini
+++ b/configs/rtlsdr.ini
@@ -21,8 +21,12 @@ bias_tee = false
 # Optional: frequency correction in PPM
 # ppm = 0
 
-# Optional: tuner bandwidth in Hz (e.g. 3000000)
-# tuner_bandwidth = 3000000
+# Tuner bandwidth in Hz. For common R820T/R820T2 receivers at the commonly used
+# 2.4 and 2.56 Msps rates, 3000000 selects the 6 MHz IF filter state. Pinning
+# it avoids backend-dependent automatic selection; paired tests at 2.4 Msps
+# found this state better than the narrower 2.43 MHz state. Other tuner types
+# or sample rates may need a different value.
+tuner_bandwidth = 3000000
 
 # Experimental LNA, MIXER, VGA controls via RTL-SDR-Blog fork.
 # The table below shows the mapping between gain control values and LNA, MIX, VGA values.

--- a/include/devices/RtlSdrDevice.hpp
+++ b/include/devices/RtlSdrDevice.hpp
@@ -60,6 +60,7 @@ private:
     };
 
     ShadowState m_state;
+    bool m_initialConfigApplied = false;
 
     rtlsdr_dev_t* m_dev = nullptr;
     std::thread   m_thread;

--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -418,6 +418,19 @@ void RtlSdrDevice::applyConfigPreOpen(const IniConfig::Section& cfg) {
 // Reload logic
 // ----------------------
 void RtlSdrDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
+    if (!m_initialConfigApplied) {
+        m_initialConfigApplied = true;
+
+        if (!cfg.count("tuner_bandwidth")
+                && rtlsdr_get_tuner_type(m_dev) == RTLSDR_TUNER_R820T) {
+            Log::warn("RtlSdrDevice")
+                << "No tuner_bandwidth configured for this R820T/R820T2 tuner; "
+                   "automatic IF filter selection depends on the sample rate and "
+                   "librtlsdr implementation. Set it explicitly (for example, "
+                   "3000000 at 2.4 or 2.56 Msps) to make the tuner state reproducible.";
+        }
+    }
+
     for (auto& [key, value] : cfg) {
 
         if (key == "serial")


### PR DESCRIPTION
## Summary

- Set tuner_bandwidth = 3000000 in the supplied RTL-SDR configuration.
- Document why this is the intended default for common R820T/R820T2 receivers at 2.4 and 2.56 Msps.
- Warn when an R820T/R820T2 starts from a custom configuration without an explicit tuner bandwidth.

## Why

For R820T/R820T2, the bandwidth request selects a discrete IF filter state rather than an arbitrary-width filter. At 2.4 Msps, automatic selection with the system librtlsdr lands in the narrow 2.43 MHz ladder state, while an explicit 3000000 Hz request selects the 6 MHz IF state. The vendored RTL-SDR Blog fork can reach a different automatic state because it reinitializes the tuner during startup, so leaving the value implicit also makes behavior backend-dependent.

A paired A/B at 2.4 Msps used two receivers on the same antenna, with receiver roles swapped mid-run to cancel dongle asymmetry. The 6 MHz state decoded about 12% more frames than the 2.43 MHz state. At 2.56 Msps the automatic system-library selection already reaches the 6 MHz state; keeping the request explicit makes the analog state reproducible across supported librtlsdr implementations.

The warning is deliberately narrower than the configuration option: it is emitted only after librtlsdr identifies RTLSDR_TUNER_R820T, which covers R820T/R820T2, only when tuner_bandwidth is absent, and only during the initial configuration. Other tuner families do not receive the warning, and reloads do not repeat it.

Other tuner types or sample rates may need a different bandwidth; both the INI comments and README call this out.

## Validation

Tested after rebasing onto current main:

- System librtlsdr build: 11/11 tests passed.
- Vendored RTL-SDR Blog build: 11/11 tests passed.
- git diff --check passes.