### PR TITLE
Report RTL-SDR startup configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The latter ones are passed via command line, while the device specific ones are 
 The stream1090 directory contains a folder named ```./configs```. There you can find two device specific files, ```rtlsdr.ini``` and ```airspy.ini```. 
 Edit the corresponding file for your device and read the comments. For now you may only want to adjust the gain settings with one exception:
 
+For RTL-SDR devices, the startup diagnostics identify the linked librtlsdr backend, the detected tuner, and whether the tuner bandwidth was explicitly configured. An `auto` bandwidth setting means librtlsdr derives it from the selected sample rate.
+
 **Important:** If you are powering an LNA via bias-tee, you have to turn that on by setting ```bias_tee = true```. It is off by default.
 
 ### Minimal running example

--- a/include/devices/RtlSdrDevice.hpp
+++ b/include/devices/RtlSdrDevice.hpp
@@ -60,6 +60,7 @@ private:
     };
 
     ShadowState m_state;
+    bool m_stateReported = false;
 
     rtlsdr_dev_t* m_dev = nullptr;
     std::thread   m_thread;

--- a/main.cpp
+++ b/main.cpp
@@ -325,6 +325,14 @@ int main(int argc, char** argv) {
                 return 1;
             }
 
+            // Name whether librtlsdr is vendored or externally provided so
+            // bug reports carry the build configuration that selected it.
+            if (GlobalOptions::RtlSdrBlogAdvanced) {
+                std::cerr << "[Stream1090] RTL-SDR backend: vendored rtl-sdr-blog fork" << std::endl;
+            } else {
+                std::cerr << "[Stream1090] RTL-SDR backend: external librtlsdr" << std::endl;
+            }
+
         } else {
             std::cerr << "[Stream1090] Error. Config file does not contain [airspy] or [rtlsdr] section." << std::endl;
             return 1;
@@ -420,7 +428,6 @@ int main(int argc, char** argv) {
     }
     return *outcome ? 0 : 1;
 }
-
 
 
 

--- a/src/devices/RtlSdrDevice.cpp
+++ b/src/devices/RtlSdrDevice.cpp
@@ -138,7 +138,21 @@ bool RtlSdrDevice::open_with_serial(uint64_t serial) {
 }
 
 bool RtlSdrDevice::open() {
-    return open_with_serial(m_serialString);
+    if (!open_with_serial(m_serialString))
+        return false;
+
+    const char* tunerName = "unknown";
+    switch (rtlsdr_get_tuner_type(m_dev)) {
+        case RTLSDR_TUNER_R820T:  tunerName = "R820T/R820T2"; break;
+        case RTLSDR_TUNER_R828D:  tunerName = "R828D"; break;
+        case RTLSDR_TUNER_E4000:  tunerName = "E4000"; break;
+        case RTLSDR_TUNER_FC0012: tunerName = "FC0012"; break;
+        case RTLSDR_TUNER_FC0013: tunerName = "FC0013"; break;
+        case RTLSDR_TUNER_FC2580: tunerName = "FC2580"; break;
+        default: break;
+    }
+    std::cerr << "[RtlSdrDevice] Tuner: " << tunerName << std::endl;
+    return true;
 }
 
 // ----------------------
@@ -424,5 +438,16 @@ void RtlSdrDevice::applyConfigPostOpen(const IniConfig::Section& cfg) {
             continue; // immutable
 
         applySetting(key, value);
+    }
+
+    // Report the bandwidth setting once. librtlsdr has no read-back API for
+    // the effective bandwidth it derives when tuner_bandwidth is omitted.
+    if (!m_stateReported) {
+        m_stateReported = true;
+        std::cerr << "[RtlSdrDevice] Tuner bandwidth setting: "
+                  << (m_state.tuner_bandwidth
+                          ? std::to_string(m_state.tuner_bandwidth) + " Hz (explicit)"
+                          : std::string("auto (derived by librtlsdr from sample rate)"))
+                  << std::endl;
     }
 }


### PR DESCRIPTION
## Summary

- report whether RTL-SDR support uses the vendored rtl-sdr-blog fork or an external librtlsdr
- report the detected tuner after the device opens successfully
- report whether tuner bandwidth is explicit or automatically derived from the sample rate
- document the startup diagnostics in the README

These details make RTL-SDR behavior reports easier to compare across builds and tuners. The automatic bandwidth is deliberately described as a setting rather than an effective read-back because librtlsdr exposes no corresponding getter.

## Testing

- system/external librtlsdr build: 11/11 tests passed
- `ENABLE_RTLSDR_BLOG=ON` build: 11/11 tests passed
- `git diff --check`

Runtime output was not hardware-tested with an RTL-SDR dongle.