### PR TITLE
Fix DF18 validation and prevent DF19 repairs from establishing trust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ if(BUILD_TESTING)
         ${PREAMBLE_THRESHOLD_DEF}
         ${MIN_SNR_DEF}
     )
+    stream1090_add_test(df18_fine_tisb_regression_test tests/Df18FineTisbRegressionTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ if(BUILD_TESTING)
         ${MIN_SNR_DEF}
     )
     stream1090_add_test(df18_fine_tisb_regression_test tests/Df18FineTisbRegressionTest.cpp)
+    stream1090_add_test(df19_repair_trust_regression_test tests/Df19RepairTrustRegressionTest.cpp)
 endif()
 
 # ------------------------------------------------------------

--- a/README_ADV.md
+++ b/README_ADV.md
@@ -92,12 +92,25 @@ DF18 shares the CA bit position with DF17, but that field is CF (Control
 Field) on DF18, not CA -- CF=2 ("Fine TIS-B Message") is a common, legitimate
 value that used to be rejected by the CA-specific check on first sighting, so
 it could never earn trust. `Plausibility::checkDF17()`'s CA range check now
-only applies to genuinely DF17-shaped frames (native DF17, or a DF19 message
-promoted to 17 -- see below); a native DF18 report is screened by
+excludes native DF18 explicitly; the only other frames reaching that line are
+native DF17 (a DF19 promoted to 17 never reaches it for an address that is
+not already trusted -- see below). A native DF18 report is screened by
 `checkICAO()` alone. This does not address non-ICAO addresses: DF18 CF=1/5
 reports, and CF=2/3 with IMF=1, carry an anonymous address or a Mode-A/track
 number rather than a 24-bit ICAO address, and stream1090's ICAO-keyed cache
 still does not distinguish those from an ordinary ICAO-addressed report.
+
+A DF19 candidate is treated as a possibly-corrupted DF17 (bit 108 flipped,
+CRC adjusted) before the crc==0 check runs, so a frame that only reaches
+crc==0 this way is a guessed repair, not a genuine clean reception. Such a
+frame is now accepted or rejected -- before the `checkICAO()`/`checkDF17()`
+validation a genuinely clean new DF17 goes through, and it never reaches
+either check -- based on whether the address it names is already trusted
+from an earlier clean reception: it can neither seed trust for an unknown
+address nor promote a known-but-not-yet-trusted one, and it leaves no
+trust-candidate sighting behind for a later clean reception to complete.
+Recovery of the original DF17 frame for an address already trusted is
+unaffected.
 
 Important: If you want to see the statistics for the whole file and not every 5 seconds. You can enable the a summary at the end by rebuilding stream with after the following cmake call in the build directory
 ```

--- a/README_ADV.md
+++ b/README_ADV.md
@@ -88,6 +88,17 @@ DF11 all-call replies may overlay the CRC parity with a non-zero II/SI interroga
 
 For DF0/4/5/16/20/21 address-parity replies, altitude and squawk checks normally reject implausible values. A rejected frame from an already active ICAO address is nevertheless accepted after the identical complete frame is received again between 100 microseconds and two seconds later. The first observation is withheld, short and long frames cannot confirm each other, and cache collisions can only discard a candidate. Corroborated Gillham or unsupported metric altitude replies do not update the stored altitude reference.
 
+DF18 shares the CA bit position with DF17, but that field is CF (Control
+Field) on DF18, not CA -- CF=2 ("Fine TIS-B Message") is a common, legitimate
+value that used to be rejected by the CA-specific check on first sighting, so
+it could never earn trust. `Plausibility::checkDF17()`'s CA range check now
+only applies to genuinely DF17-shaped frames (native DF17, or a DF19 message
+promoted to 17 -- see below); a native DF18 report is screened by
+`checkICAO()` alone. This does not address non-ICAO addresses: DF18 CF=1/5
+reports, and CF=2/3 with IMF=1, carry an anonymous address or a Mode-A/track
+number rather than a 24-bit ICAO address, and stream1090's ICAO-keyed cache
+still does not distinguish those from an ordinary ICAO-addressed report.
+
 Important: If you want to see the statistics for the whole file and not every 5 seconds. You can enable the a summary at the end by rebuilding stream with after the following cmake call in the build directory
 ```
 cmake ../ --fresh -DEND_STATS=ON -DENABLE_STATS=ON && make

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -286,6 +286,11 @@ public:
 
 		auto crc = m_shiftRegisters.getCRC_112(streamIndex);
 
+		// A frame that only reaches crc==0 by way of the DF19->17 guess below
+		// is a repair, not a genuine clean reception; captured before the
+		// guess overwrites downlinkFormat, so the two stay distinguishable.
+		const bool wasDf19 = (downlinkFormat == 19);
+
 		// This is very hacky. However, we do not know about DF-19 nor seems to be many decoders.
 		// We will give it a try as a DF-17 message since 17 and 19 have hamming distance 1
 		if (downlinkFormat==19) {
@@ -307,10 +312,24 @@ public:
 			
 			// if we know this plane
 			if (e.isValid()) {
+				// A repair-shaped (DF19->17) frame may only refresh trust that
+				// already exists; it must not be the thing that grants it to a
+				// known-but-not-yet-trusted entry (e.g. one still waiting on
+				// its own second sighting).
+				if (wasDf19 && !m_cache.isTrusted(e))
+					return false;
 				m_cache.markAsTrustedSeen(e);
 				// and send the 112 bit message to the output
 				return sendFrameLongAligned(streamIndex, downlinkFormat, crc, frame, e);
 			} else {
+				// A frame that only reads crc==0 because of the DF19->17 guess
+				// is a repair, not a genuine clean reception: for an address
+				// that is not already known (the case just above), it must not
+				// seed trust, nor register a trust-candidate sighting for a
+				// later clean reception to complete.
+				if (wasDf19)
+					return false;
+
 				if (!Plausibility::checkICAO(icaoWithCA & 0xFFFFFF)) {
 					Log::debug("DemodCore") << "Trying to insert invalid icao from DF-17 " << std::hex << (icaoWithCA & 0xFFFFFF);
 					return false;
@@ -319,9 +338,11 @@ public:
 				// DF18's bits here are CF (Control Field), not DF17's CA: CF
 				// values 1-3 are ordinary DF18 report types (e.g. CF=2 Fine
 				// TIS-B with a real ICAO address), not "no ADS-B capability"
-				// as they would be for DF17's CA. checkDF17() applies only to
-				// DF17 (native, or a DF19 promoted above: both are
-				// DF17-shaped by this point).
+				// as they would be for DF17's CA. Excluding DF18 here is
+				// enough to reach only native DF17: a DF19 promoted to 17
+				// never reaches this line for an address that is not
+				// already trusted -- it is accepted or rejected by the
+				// wasDf19 checks above, before this validation runs.
 				if (downlinkFormat != 18 && !Plausibility::checkDF17(frame)) {
 					Log::debug("DemodCore") << "Trying to insert by wrong DF-17 message  " << std::hex << (icaoWithCA & 0xFFFFFF);
 					return false;

--- a/include/DemodCore.hpp
+++ b/include/DemodCore.hpp
@@ -316,7 +316,13 @@ public:
 					return false;
 				}
 
-				if (!Plausibility::checkDF17(frame)) {
+				// DF18's bits here are CF (Control Field), not DF17's CA: CF
+				// values 1-3 are ordinary DF18 report types (e.g. CF=2 Fine
+				// TIS-B with a real ICAO address), not "no ADS-B capability"
+				// as they would be for DF17's CA. checkDF17() applies only to
+				// DF17 (native, or a DF19 promoted above: both are
+				// DF17-shaped by this point).
+				if (downlinkFormat != 18 && !Plausibility::checkDF17(frame)) {
 					Log::debug("DemodCore") << "Trying to insert by wrong DF-17 message  " << std::hex << (icaoWithCA & 0xFFFFFF);
 					return false;
 				}

--- a/tests/Df18FineTisbRegressionTest.cpp
+++ b/tests/Df18FineTisbRegressionTest.cpp
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Regression: handleExtSquitterLongMessage() applies Plausibility::checkDF17()
+// to every extended squitter that reaches the first-sighting insert, DF18
+// included. DF18 uses the same bit position for CF (Control Field) that
+// DF17 uses for CA (transponder capability); checkDF17() rejects CA values
+// 1-3, which also rejects CF=2 ("Fine TIS-B Message", a report carrying a
+// genuine ICAO address -- see readsb's mode_s.c, decodeExtendedSquitter()).
+// A legitimate CF=2 report is therefore rejected on its first sighting and
+// can never earn trust, no matter how many times it repeats.
+//
+// Expected: a repeated DF18 CF=2 report earns trust and is emitted
+// unchanged, exactly like an equivalent DF17 report (checked here as a
+// positive control on the same harness, to isolate the bug to DF18).
+//
+// Driven through the public bit-level entry point (DemodCore::shiftInNewBits)
+// only.
+
+#include "DemodCore.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t Address = 0x4CA2D1; // passes Plausibility::checkICAO()
+
+struct CollectHandler {
+    void handleShort(uint64_t, uint64_t) {}
+    void handleLong(uint64_t, const Bits128& frame) { longFrames.push_back(frame); }
+
+    std::vector<Bits128> longFrames;
+};
+
+// DF (5 bits) + CF/CA (3 bits) + AA/ICAO (24 bits) + ME typecode 11
+// ("airborne position") with varying CPR bits: df=18 cf=2 is Fine TIS-B
+// with a real ICAO address, df=17 ca=5 is the equivalent genuine ADS-B
+// report used below as the positive control.
+Bits128 makeExtSquitterPosition(uint8_t df, uint8_t cfOrCa, uint32_t icao,
+        uint32_t latCpr, uint32_t lonCpr, bool odd) {
+    const uint64_t high = (uint64_t(df) << 43)
+        | (uint64_t(cfOrCa) << 40)
+        | (uint64_t(icao) << 16)
+        | (uint64_t(11) << 11); // TC 11: airborne position
+    const uint64_t low = (uint64_t(odd) << 58)
+        | (uint64_t(latCpr) << 41)
+        | (uint64_t(lonCpr) << 24);
+    Bits128 frame(high, low);
+    frame.low() |= CRC::compute<112>(frame);
+    return frame;
+}
+
+void feedFrame(DemodCore<1, CollectHandler>& demod, const Bits128& frame) {
+    for (int bit = 111; bit >= 0; --bit) {
+        uint32_t value[] = { uint32_t(frame.get(bit)) };
+        demod.shiftInNewBits(value);
+    }
+}
+
+void feedQuiet(DemodCore<1, CollectHandler>& demod, int ticks) {
+    for (int i = 0; i < ticks; ++i) {
+        uint32_t value[] = { 0 };
+        demod.shiftInNewBits(value);
+    }
+}
+
+// Sends three varying reports of the same address (CPR longitude nudged
+// each time so phase dedup cannot hide whether the address itself earned
+// trust), each more than 100 us and less than 2 s apart, and returns every
+// long frame emitted along the way.
+std::vector<Bits128> sendThreeReports(uint8_t df, uint8_t cfOrCa) {
+    CollectHandler handler;
+    DemodCore<1, CollectHandler> demod(handler);
+    feedQuiet(demod, 1000); // warm-up
+
+    const auto m1 = makeExtSquitterPosition(df, cfOrCa, Address, 93000, 51372, false);
+    const auto m2 = makeExtSquitterPosition(df, cfOrCa, Address, 93000, 51373, false);
+    const auto m3 = makeExtSquitterPosition(df, cfOrCa, Address, 93000, 51374, false);
+
+    if (CRC::compute<112>(m1) != 0 || CRC::compute<112>(m2) != 0
+            || CRC::compute<112>(m3) != 0) {
+        std::printf("fixture error: constructed frame is not CRC-clean\n");
+        return {};
+    }
+    if (m1.low() == m2.low() || m2.low() == m3.low()) {
+        std::printf("fixture error: successive reports are bit-identical\n");
+        return {};
+    }
+
+    feedFrame(demod, m1);
+    feedQuiet(demod, 300); // > 100 us, < 2 s
+    feedFrame(demod, m2);
+    feedQuiet(demod, 300);
+    feedFrame(demod, m3);
+    feedQuiet(demod, 1000);
+
+    return handler.longFrames;
+}
+
+} // namespace
+
+int main() {
+    int failures = 0;
+
+    // Positive control: an equivalent DF17 report (CA=5, valid capability)
+    // earns trust and is emitted unchanged by the second and third
+    // sighting. If this fails, the harness is broken, not the DF18 path.
+    {
+        const auto emitted = sendThreeReports(17, 5);
+        const auto expected2 = makeExtSquitterPosition(17, 5, Address, 93000, 51373, false);
+        const auto expected3 = makeExtSquitterPosition(17, 5, Address, 93000, 51374, false);
+        if (emitted.size() != 2 || emitted[0] != expected2 || emitted[1] != expected3) {
+            std::printf("DF17 positive control failed: expected the second "
+                "and third report emitted unchanged, got %zu long frame(s)\n",
+                emitted.size());
+            ++failures;
+        }
+    }
+
+    // The regression: DF18 CF=2 must behave identically to the DF17
+    // control above.
+    {
+        const auto emitted = sendThreeReports(18, 2);
+        const auto expected2 = makeExtSquitterPosition(18, 2, Address, 93000, 51373, false);
+        const auto expected3 = makeExtSquitterPosition(18, 2, Address, 93000, 51374, false);
+        if (emitted.size() != 2 || emitted[0] != expected2 || emitted[1] != expected3) {
+            std::printf("DF18 CF=2 (Fine TIS-B) never earned trust: expected "
+                "the second and third report emitted unchanged, got %zu long "
+                "frame(s)\n", emitted.size());
+            ++failures;
+        }
+    }
+
+    if (failures == 0) {
+        std::printf("DF18 Fine TIS-B: earns trust and is emitted like DF17\n");
+        return 0;
+    }
+    std::printf("FAILED with %d problem(s)\n", failures);
+    return 1;
+}

--- a/tests/Df19RepairTrustRegressionTest.cpp
+++ b/tests/Df19RepairTrustRegressionTest.cpp
@@ -1,0 +1,270 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Regression: handleExtSquitterLongMessage() treats every DF19 candidate as
+// a possibly-corrupted DF17: it flips bit 108 (the DF field's
+// second-least-significant bit, where 17 = 10001 and 19 = 10011 differ) and
+// XORs the CRC by CRC::delta<108>() before the crc==0 check runs. When the
+// flip lands on a real single-bit error, the reconstructed frame's CRC
+// becomes zero and is treated exactly like a genuinely clean squitter, with
+// nothing distinguishing a guessed repair from an actual clean reception.
+// Repeating a repair-shaped signal can therefore create trust for an
+// address that was never cleanly received.
+//
+// Three independent cases, driven through the public bit-level entry point
+// only:
+//   A) a brand-new address, signal shaped so the DF field flips 19->17 --
+//      nothing may ever be emitted, and trust must never appear.
+//   C) an address with exactly one prior clean DF17 sighting, so it is
+//      already in the cache but not yet trusted (a second sighting is what
+//      earns trust) -- the same repair-shaped signal must still neither
+//      emit nor promote it.
+//   B) an address already trusted through clean DF17 sightings, then the
+//      same bit-108 error on a message for that address -- recovery is
+//      allowed to emit the corrected, original DF17 frame; that is
+//      legitimate error correction for an address already vetted, not
+//      trust creation.
+//
+// Case C is the one a fix can get wrong by assuming any cache hit found by
+// findWithCA() is already trusted: it is not, until a second sighting (or
+// this same repair, if left unguarded) confirms it.
+//
+// This test does not call into Plausibility:: at all. A dedicated positive
+// control (below) confirms with DemodCore's own public behavior that the
+// address used in case A is not rejected for some unrelated reason.
+
+#include "DemodCore.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+struct CollectHandler {
+    void handleShort(uint64_t, uint64_t) {}
+    void handleLong(uint64_t, const Bits128& frame) { longFrames.push_back(frame); }
+
+    std::vector<Bits128> longFrames;
+};
+
+Bits128 makeDf17Position(uint32_t icao, uint32_t latCpr, uint32_t lonCpr, bool odd) {
+    const uint64_t high = (uint64_t(17) << 43)
+        | (uint64_t(5) << 40)
+        | (uint64_t(icao) << 16)
+        | (uint64_t(11) << 11);
+    const uint64_t low = (uint64_t(odd) << 58)
+        | (uint64_t(latCpr) << 41)
+        | (uint64_t(lonCpr) << 24);
+    Bits128 frame(high, low);
+    frame.low() |= CRC::compute<112>(frame);
+    return frame;
+}
+
+// A genuinely valid DF17 report with bit 108 flipped: the DF field now
+// reads 19, and the raw CRC over the received bits is CRC::delta<108>()
+// (nonzero) -- the exact signal shape the DF19->17 promotion "recovers"
+// back to this same DF17 frame.
+Bits128 asDf19WithBit108Error(Bits128 df17) {
+    df17.flip(108);
+    return df17;
+}
+
+void feedFrame(DemodCore<1, CollectHandler>& demod, const Bits128& frame) {
+    for (int bit = 111; bit >= 0; --bit) {
+        uint32_t value[] = { uint32_t(frame.get(bit)) };
+        demod.shiftInNewBits(value);
+    }
+}
+
+void feedQuiet(DemodCore<1, CollectHandler>& demod, int ticks) {
+    for (int i = 0; i < ticks; ++i) {
+        uint32_t value[] = { 0 };
+        demod.shiftInNewBits(value);
+    }
+}
+
+uint8_t receivedDf(const Bits128& frame) {
+    return uint8_t((frame.high() >> 43) & 0x1F);
+}
+
+} // namespace
+
+int main() {
+    int failures = 0;
+
+    // --- Case A: brand-new, never-seen address -----------------------
+    // 0x1A2B3C: verified below, via a live positive control, to pass
+    // whatever address-plausibility screening exists on this reference.
+    // Using an address that unrelated screening would itself reject would
+    // pass this test for the wrong reason.
+    constexpr uint32_t unknownAddress = 0x1A2B3C;
+    {
+        CollectHandler handler;
+        DemodCore<1, CollectHandler> demod(handler);
+        feedQuiet(demod, 1000);
+        const auto p1 = makeDf17Position(unknownAddress, 20000, 20000, false);
+        const auto p2 = makeDf17Position(unknownAddress, 20000, 20001, false);
+        feedFrame(demod, p1);
+        feedQuiet(demod, 300); // > 100 us, < 2 s
+        feedFrame(demod, p2); // second clean sighting: trusted, emitted
+        feedQuiet(demod, 300);
+        if (handler.longFrames.size() != 1 || handler.longFrames[0] != p2) {
+            std::printf("positive control failed: two genuinely clean DF17 "
+                "sightings of 0x1A2B3C did not earn trust and get emitted "
+                "(%zu long frame(s)) -- pick a different address\n",
+                handler.longFrames.size());
+            return 1;
+        }
+    }
+
+    const auto clean1 = makeDf17Position(unknownAddress, 93000, 51372, false);
+    const auto clean2 = makeDf17Position(unknownAddress, 93000, 51373, false);
+    const auto clean3 = makeDf17Position(unknownAddress, 93000, 51374, false);
+    const auto signal1 = asDf19WithBit108Error(clean1);
+    const auto signal2 = asDf19WithBit108Error(clean2);
+    const auto signal3 = asDf19WithBit108Error(clean3);
+
+    // fixture sanity: each signal presents as DF 19 with the syndrome the
+    // bit-108 flip predicts, and reconstructs a genuinely clean DF17 frame.
+    auto checkFixture = [](const Bits128& clean, const Bits128& signal) {
+        if (CRC::compute<112>(clean) != 0) {
+            std::printf("fixture error: clean DF17 frame is not CRC-clean\n");
+            return false;
+        }
+        if (receivedDf(signal) != 19) {
+            std::printf("fixture error: bit-108 flip did not turn DF 17 into 19\n");
+            return false;
+        }
+        if (CRC::compute<112>(signal) != CRC::delta<108>()) {
+            std::printf("fixture error: flipped frame's syndrome is not "
+                "CRC::delta<108>()\n");
+            return false;
+        }
+        return true;
+    };
+    if (!checkFixture(clean1, signal1) || !checkFixture(clean2, signal2)
+            || !checkFixture(clean3, signal3))
+        return 1;
+
+    {
+        CollectHandler handler;
+        DemodCore<1, CollectHandler> demod(handler);
+        feedQuiet(demod, 1000);
+        feedFrame(demod, signal1);
+        feedQuiet(demod, 300); // > 100 us, < 2 s
+        feedFrame(demod, signal2);
+        feedQuiet(demod, 300);
+        feedFrame(demod, signal3);
+        feedQuiet(demod, 1000);
+
+        // Frames that require repair must never seed trust for an address
+        // that has never been cleanly received. Nothing may be emitted.
+        if (!handler.longFrames.empty()) {
+            std::printf("Case A (unknown address): %zu frame(s) emitted from "
+                "a repeated DF19-shaped signal for an address never cleanly "
+                "received -- a repair created trust for a brand-new address\n",
+                handler.longFrames.size());
+            ++failures;
+        }
+
+        // Corroborate independently: if trust had been created, a later
+        // genuinely clean DF17 for the same address would be emitted on
+        // its very first (post-promotion) sighting instead of needing its
+        // own separate two-sighting confirmation.
+        const auto probe = makeDf17Position(unknownAddress, 10000, 10000, true);
+        feedFrame(demod, probe);
+        feedQuiet(demod, 1000);
+        const bool probeEmittedImmediately = !handler.longFrames.empty()
+            && handler.longFrames.back() == probe;
+        if (probeEmittedImmediately) {
+            std::printf("Case A corroboration: a fresh clean DF17 for the "
+                "same address was emitted on first sighting -- the address "
+                "was already (wrongly) trusted\n");
+            ++failures;
+        }
+    }
+
+    // --- Case C: known but not yet trusted (one prior clean sighting) --
+    // 0x1E7C42: a distinct address from case A/B, needed only so this case's
+    // own DemodCore instance starts from a single untrusted sighting rather
+    // than none or two.
+    constexpr uint32_t knownUntrustedAddress = 0x1E7C42;
+    {
+        CollectHandler handler;
+        DemodCore<1, CollectHandler> demod(handler);
+        feedQuiet(demod, 1000);
+
+        const auto first = makeDf17Position(knownUntrustedAddress, 40000, 40000, false);
+        feedFrame(demod, first); // first sighting: inserted, untrusted
+        feedQuiet(demod, 300);
+
+        const auto repaired1 = makeDf17Position(knownUntrustedAddress, 70000, 71000, true);
+        feedFrame(demod, asDf19WithBit108Error(repaired1));
+        feedQuiet(demod, 300);
+
+        if (!handler.longFrames.empty()) {
+            std::printf("Case C (known, untrusted address): %zu frame(s) "
+                "emitted from a DF19-shaped repair for an address with only "
+                "one prior clean sighting -- a repair promoted a "
+                "known-but-untrusted entry\n", handler.longFrames.size());
+            ++failures;
+        }
+
+        // Corroborate: if that repair had wrongly promoted the entry to
+        // trusted, a second DF19-shaped repair would now be allowed to
+        // emit (recovery is legitimate for a trusted address, see case B).
+        const auto repaired2 = makeDf17Position(knownUntrustedAddress, 72000, 73000, false);
+        feedFrame(demod, asDf19WithBit108Error(repaired2));
+        feedQuiet(demod, 300);
+
+        if (!handler.longFrames.empty()) {
+            std::printf("Case C corroboration: a second DF19-shaped repair "
+                "emitted %zu frame(s) -- the first repair had already "
+                "(wrongly) promoted the address to trusted\n",
+                handler.longFrames.size());
+            ++failures;
+        }
+    }
+
+    // --- Case B: address already trusted through clean sightings -----
+    constexpr uint32_t trustedAddress = 0x39B4C1;
+    {
+        CollectHandler handler;
+        DemodCore<1, CollectHandler> demod(handler);
+        feedQuiet(demod, 1000);
+
+        const auto t1 = makeDf17Position(trustedAddress, 93000, 51372, false);
+        const auto t2 = makeDf17Position(trustedAddress, 74158, 50194, true);
+        feedFrame(demod, t1);
+        feedQuiet(demod, 300);
+        feedFrame(demod, t2); // second clean sighting: trusted, emitted
+        feedQuiet(demod, 300);
+
+        if (handler.longFrames.size() != 1 || handler.longFrames[0] != t2) {
+            std::printf("Case B setup failed: address did not become "
+                "trusted through two clean DF17 sightings as expected\n");
+            ++failures;
+        } else {
+            const auto original = makeDf17Position(trustedAddress, 60000, 40000, false);
+            const auto damaged = asDf19WithBit108Error(original);
+            feedFrame(demod, damaged);
+            feedQuiet(demod, 300);
+
+            const bool recovered = handler.longFrames.size() == 2
+                && handler.longFrames[1] == original;
+            if (!recovered) {
+                std::printf("Case B: recovery for an already-trusted address "
+                    "did NOT emit the original DF17 frame (%zu long frame(s) "
+                    "total)\n", handler.longFrames.size());
+                ++failures;
+            }
+        }
+    }
+
+    if (failures == 0) {
+        std::printf("DF19->17 promotion never seeds trust for a new address\n");
+        return 0;
+    }
+    std::printf("FAILED with %d problem(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## What this fixes

Two production bugs in extended-squitter plausibility/trust handling, extracted from #67 (`demod/trust-only-parity`) so they can be reviewed independently of that PR's broader address-parity trust-policy change.

**1. DF18 CF misread as DF17 CA.** `handleExtSquitterLongMessage()` applied `Plausibility::checkDF17()`'s CA range check (rejects CA 1-3) to every extended squitter reaching the first-sighting insert, DF18 included. DF18 uses the same bit position for CF (Control Field), not CA — CF=2 ("Fine TIS-B Message", a genuine ICAO address) fell inside the rejected range, so a legitimate CF=2 report could never earn trust. The check now excludes native DF18 explicitly; the only other frames reaching that line are native DF17 (a DF19 promoted to 17 never reaches it for an address that is not already trusted — see point 2). A native DF18 report is screened by `checkICAO()` alone. This does **not** address DF18's non-ICAO address cases (CF=1/5, CF=2/3 with IMF=1) — documented as a residual limitation in README_ADV.md, not claimed as fixed.

**2. DF19→DF17 repairs could seed or promote trust.** A DF19 candidate is treated as a possibly-corrupted DF17 (bit 108 flipped, CRC adjusted) before the `crc==0` check runs. When the flip landed on a real single-bit error, the reconstructed frame reached the same trust door a genuinely clean DF17 uses, with nothing distinguishing a guessed repair from an actual clean reception — a repeated, structurally-plausible DF19-shaped signal could create trust for an address never cleanly received, or promote a known-but-not-yet-trusted one. The fix tracks whether a frame arrived as DF19 before the guess overwrites `downlinkFormat`; such a frame can now only *refresh* trust for an address `isTrusted()` already confirms, and is accepted or rejected — for every other case (unknown, or known but not yet trusted) — before `checkICAO()`/`checkDF17()`/`confirmTrustCandidate()` ever run, so it neither seeds trust nor leaves a trust-candidate sighting behind for a later clean reception to complete. Recovery for an already-trusted address is unaffected.

Note: upstream's "known address" branch treats any `findWithCA()` hit as trusted without itself checking `isTrusted()`, which differs from #67's own structure there — the fix here gates explicitly on `isTrusted()` rather than assuming that branch already implies trust, to avoid a known-but-untrusted entry acquiring trust through a repair.

## Out of scope (from #67)

- The general address-parity trust-policy change (replacing SNR/preamble gates on DF0/4/5/16/20/21 with trust-only gating).
- The DF11 PI/ICAO bypass fix and its test — that bug is specific to #67's own restructuring of the DF11 `crc<80` path and does not exist on this branch (upstream is not affected by it).

## Tests

Added `df18_fine_tisb_regression_test` and `df19_repair_trust_regression_test` (registered in CMakeLists.txt), ported from #67's red-phase regression commit and adapted with shortened comments. Both drive the bugs through the public bit-level entry point only (`DemodCore::shiftInNewBits`).

`df19_repair_trust_regression_test` covers three cases: **A)** a brand-new address (never seen), **B)** an address already trusted through clean DF17 sightings (recovery must still work), and **C)** an address with exactly one prior clean sighting — known, but not yet trusted, since a second sighting is what normally earns trust. Case C is the one a naive fix can get wrong by assuming any cache hit is already trusted; it's corroborated by a second repair attempt, which would itself wrongly emit if the first had promoted the entry.

Reproduced against unmodified `origin/main` (edf006a):
- `df18_fine_tisb_regression_test`: **FAILED** — 0 of 2 expected long frames emitted for DF18 CF=2.
- `df19_repair_trust_regression_test`: **FAILED** — case A emitted 2 frames and left the address trusted; case C emitted 1 frame on the first repair (and a further frame on the corroborating second repair, confirming the entry had been wrongly promoted); case B alone passed.

Full suite before (unmodified, tests added but no fix): 11/13 pass, exactly these 2 fail.
Full suite after (with both fixes): **13/13 pass**, including all pre-existing tests, clean build.

See [PR #67](https://github.com/mgrone/stream1090/pull/67) for full context; this PR does not include that PR's DF11 PI/ICAO bypass fix, which is specific to #67's own code and not an upstream issue.
