### PR TITLE
Sample-drop monitor: make USB/FIFO sample loss visible and bounded

### DIFF
--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -18,6 +18,9 @@
 #include "devices/IniConfig.hpp"
 #include "devices/DeviceFactory.hpp"
 #include <chrono>
+#include <deque>
+#include <cstdlib>
+#include <algorithm>
 #include <optional>
 #include <sstream>
 #include <unistd.h>
@@ -176,6 +179,30 @@ public:
         std::thread watchdog([this, &intendedShutdown] {
             using namespace std::chrono_literals;
             Log::info("Watchdog", "Started.");
+
+            // -------------------------------
+            // SAMPLE-DROP MONITOR STATE
+            //
+            // The detection runs on the device callback thread (see
+            // InputDeviceBase::writeDataToBuffer): delivered IQ pairs
+            // against the wall clock, measured at arrival. This side only
+            // warns and decides whether the run may continue. The exit
+            // policy defaults to "more than 1 drop per 60 s", overridable
+            // with STREAM1090_MAX_DROPS_PER_MIN (0 disables the exit,
+            // warnings stay on).
+            // -------------------------------
+            const uint64_t iqPairsPerSec = (uint64_t)inputRate;
+            int maxDropsPerMin = 1;
+            if (const char* env = std::getenv("STREAM1090_MAX_DROPS_PER_MIN")) {
+                try { maxDropsPerMin = std::max(0, std::stoi(env)); } catch (...) {}
+            }
+            Log::info("Watchdog") << "Sample-drop monitor active: exit after more than "
+                      << maxDropsPerMin << " drop(s) in 60 s"
+                      << (maxDropsPerMin == 1 ? " (STREAM1090_MAX_DROPS_PER_MIN to override)" : "")
+                      << ".";
+            uint64_t seenDropEvents = 0;
+            std::deque<std::chrono::steady_clock::time_point> recentDrops;
+
             while (!ProcessSignals::shutdownRequested()) {
                 if (m_device) {
                     const auto lastSign = m_device->lastSignOfLife();
@@ -211,8 +238,43 @@ public:
                     }
                 }
 
+                // 4) Sample-drop policy. The detection runs on the device
+                // callback thread; this side only warns and decides whether
+                // the run may continue.
+                if (m_device) {
+                    const auto now = std::chrono::steady_clock::now();
+                    const uint64_t events = m_device->dropEventCount();
+                    while (seenDropEvents < events) {
+                        seenDropEvents++;
+                        recentDrops.push_back(now);
+                        while (!recentDrops.empty() && now - recentDrops.front() > 60s)
+                            recentDrops.pop_front();
+                        Log::warn("Watchdog") << "Sample drop: ~"
+                                  << m_device->lastEventGrowth()
+                                  << " IQ pairs (~"
+                                  << (double)m_device->lastEventGrowth()
+                                     / (double)iqPairsPerSec * 1000.0
+                                  << " ms of stream) lost; cumulative deficit ~"
+                                  << m_device->currentDropDeficit() << " IQ pairs.";
+                        if (maxDropsPerMin > 0 && recentDrops.size() > (size_t)maxDropsPerMin) {
+                            Log::error("Watchdog") << recentDrops.size()
+                                      << " sample drops in the last 60 s (threshold: more than "
+                                      << maxDropsPerMin << "). The host cannot sustain this sample rate. "
+                                      << "Initiating shutdown.";
+                            intendedShutdown = false;
+                            m_device->shutdownWriter();
+                            ProcessSignals::handle_sigint(0);
+                            break;
+                        }
+                    }
+                }
+
                 std::this_thread::sleep_for(200ms);
             }
+            if (seenDropEvents > 0)
+                Log::warn("Watchdog") << "Sample drops during this run: "
+                          << seenDropEvents << " event(s), worst gap ~"
+                          << m_device->maxDropDeficit() << " IQ pairs.";
             Log::info("Watchdog", "Watchdog is done.");
         });
 

--- a/include/devices/InputDeviceBase.hpp
+++ b/include/devices/InputDeviceBase.hpp
@@ -11,6 +11,8 @@
 #include "IniConfig.hpp"
 #include <string>
 #include <atomic>
+#include <chrono>
+#include <cstdint>
 
 template<typename T>
 class InputDeviceBase {
@@ -18,14 +20,17 @@ public:
     using RawType = T;
 
     InputDeviceBase(SampleRate sampleRate, IAsyncWriter<T>& bufferWriter)
-        : m_sampleRate(sampleRate), m_bufferWriter(bufferWriter)
+        : m_sampleRate(sampleRate), m_bufferWriter(bufferWriter),
+          // a drop event must cost at least 2 ms of stream: far above the
+          // +-100 ppm crystal drift, far below one 256 KB USB transfer
+          m_dropEventThreshold((uint64_t)sampleRate / 500)
     {
         m_lastSignOfLife.store(std::chrono::steady_clock::now(),
                              std::memory_order_relaxed);
     }
 
     virtual ~InputDeviceBase() = default;
-    
+
     virtual bool open() = 0;
     virtual bool start() = 0;
     virtual void stop() = 0;
@@ -33,12 +38,12 @@ public:
 
     // Called before open() is called to parse things like serial, packing etc.
     virtual void applyConfigPreOpen(const IniConfig::Section&) {
-        // we do not do anything as default        
+        // we do not do anything as default
     };
 
     // Called by the watchdog after SIGHUP
     virtual void applyConfigPostOpen(const IniConfig::Section&) {
-        // we do not do anything as default        
+        // we do not do anything as default
     };
 
     // Called by device callback threads
@@ -46,7 +51,7 @@ public:
         m_lastSignOfLife.store(std::chrono::steady_clock::now(),
                              std::memory_order_relaxed);
     }
-    
+
     // Used by watchdog to detect cable pulls
     std::chrono::milliseconds lastSignOfLife() const {
         auto now  = std::chrono::steady_clock::now();
@@ -54,7 +59,85 @@ public:
         return std::chrono::duration_cast<std::chrono::milliseconds>(now - last);
     }
 
+    // Interleaved IQ: two raw elements per sample. Runs on the device
+    // callback thread; the sample-drop accounting happens here because
+    // only at arrival time is the wall clock comparable to the delivered
+    // count without paying the quantization of the USB transfer queue
+    // (one 256 KB transfer = 131072 IQ pairs = ~110 ms at 2.4 Msps).
     void writeDataToBuffer(const T* data, size_t n) {
+        const auto now = std::chrono::steady_clock::now();
+        const uint64_t pairs = m_iqPairsDelivered.fetch_add(n / 2, std::memory_order_relaxed)
+                             + n / 2;
+
+        const bool gap = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             now - m_lastAccounting).count() > 150;
+        if (m_accT0.time_since_epoch().count() == 0) {
+            // first data ever: start accounting from here
+            m_firstCallback = now;
+            m_accT0 = now;
+            m_accPairs0 = pairs;
+        } else if (gap) {
+            // streaming was paused (device startup, config reload on
+            // SIGHUP, unplug): re-baseline, the gap is operator- or
+            // driver-induced and not congestion.
+            m_accT0 = now;
+            m_accPairs0 = pairs;
+            m_histCount = 0;
+            m_dropDeficit.store(0, std::memory_order_relaxed);
+        } else {
+            const double secs = std::chrono::duration<double>(now - m_accT0).count();
+            const int64_t expected = (int64_t)((double)m_sampleRate * secs);
+            const int64_t deficit = std::max<int64_t>(
+                expected - (int64_t)(pairs - m_accPairs0), 0);
+            m_dropDeficit.store(deficit, std::memory_order_relaxed);
+            {
+                uint64_t prev = m_maxDeficit.load(std::memory_order_relaxed);
+                while (deficit > (int64_t)prev &&
+                       !m_maxDeficit.compare_exchange_weak(prev, (uint64_t)deficit,
+                                                           std::memory_order_relaxed)) {}
+            }
+            if (now - m_firstCallback < std::chrono::seconds(5)) {
+                // startup ramp: transfers hiccup while the queue fills,
+                // which is not the congestion the exit policy is for. Keep
+                // the baseline rolling so ramp-up losses never count.
+                m_accT0 = now;
+                m_accPairs0 = pairs;
+                m_histCount = 0;
+            } else {
+                // a lost sample never comes back, so a real drop leaves a
+                // deficit that persists and grows. Two confounders to keep
+                // out: a transient delivery spike (ring buffer full for a
+                // few ms) recovers and collapses the deficit again, and the
+                // crystal offset makes the cumulative deficit drift at up
+                // to ~150 ppm (under 500 pairs per second, far below the
+                // event threshold). Comparing the deficit against ~1 s ago
+                // keeps both out: real loss arrives in whole USB transfers
+                // (131072 pairs) and dwarfs the drift.
+                m_deficitHist[m_histHead] = {now, deficit};
+                m_histHead = (m_histHead + 1) % kDeficitHistory;
+                if (m_histCount < kDeficitHistory)
+                    m_histCount++;
+
+                // find the oldest sample that is at least 900 ms old
+                int64_t past = -1;
+                for (size_t i = 0; i < m_histCount; i++) {
+                    const auto& s = m_deficitHist[(m_histHead + i) % kDeficitHistory];
+                    if (now - s.t >= std::chrono::milliseconds(900)) {
+                        past = s.deficit;
+                    } else {
+                        break;
+                    }
+                }
+                if (past >= 0 && deficit - past > (int64_t)m_dropEventThreshold &&
+                    now - m_lastEventTime > std::chrono::milliseconds(500)) {
+                    m_lastEventGrowth = deficit - past;
+                    m_lastEventTime = now;
+                    m_dropEvents.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        }
+        m_lastAccounting = now;
+
         m_bufferWriter.write(data, n);
     }
 
@@ -66,6 +149,31 @@ public:
         return m_sampleRate;
     }
 
+    // ---------------------
+    // Sample-drop monitor interface (polled by the watchdog).
+    // The exit policy (more than N drops per minute) lives there; the
+    // detection happens here on the callback thread.
+    // ---------------------
+
+    // monotonic count of drop events
+    uint64_t dropEventCount() const {
+        return m_dropEvents.load(std::memory_order_relaxed);
+    }
+
+    // pairs lost in the most recent drop event (over its ~1 s window)
+    int64_t lastEventGrowth() const {
+        return m_lastEventGrowth.load(std::memory_order_relaxed);
+    }
+
+    // current cumulative deficit in IQ pairs
+    int64_t currentDropDeficit() const {
+        return m_dropDeficit.load(std::memory_order_relaxed);
+    }
+
+    uint64_t maxDropDeficit() const {
+        return m_maxDeficit.load(std::memory_order_relaxed);
+    }
+
     virtual bool isRunning() const {
         return m_running.load(std::memory_order_relaxed);
     }
@@ -74,7 +182,30 @@ protected:
     SampleRate m_sampleRate;
     IAsyncWriter<T>& m_bufferWriter;
     std::atomic<bool> m_running{false};
+    std::atomic<uint64_t> m_iqPairsDelivered{0};
 
     // timestamp when the last time the callback was called.
     std::atomic<std::chrono::steady_clock::time_point> m_lastSignOfLife;
+
+    // ---- sample-drop accounting, callback thread only ----
+    // deficit history: 32 samples cover well over 1 s of callbacks (one
+    // callback per 256 KB transfer = ~82-110 ms)
+    static constexpr size_t kDeficitHistory = 32;
+    struct DeficitSample {
+        std::chrono::steady_clock::time_point t;
+        int64_t deficit;
+    };
+    DeficitSample m_deficitHist[kDeficitHistory]{};
+    size_t m_histHead = 0;
+    size_t m_histCount = 0;
+    std::chrono::steady_clock::time_point m_lastEventTime{};
+    std::chrono::steady_clock::time_point m_lastAccounting{};
+    std::chrono::steady_clock::time_point m_firstCallback{};
+    std::chrono::steady_clock::time_point m_accT0{};
+    uint64_t m_accPairs0 = 0;
+    const uint64_t m_dropEventThreshold;
+    std::atomic<int64_t> m_dropDeficit{0};
+    std::atomic<int64_t> m_lastEventGrowth{0};
+    std::atomic<uint64_t> m_dropEvents{0};
+    std::atomic<uint64_t> m_maxDeficit{0};
 };


### PR DESCRIPTION
## Problem

A host that cannot sustain the sample rate (a Pi 4 at 3.2 Msps, a shared USB controller) loses samples **silently**: neither the RTL2832 FIFO overrun nor a libusb overflow leaves any marker in the data, and the only symptom is a frame count that quietly degrades.

## Approach

Detection runs on the **device callback thread**, in `InputDeviceBase::writeDataToBuffer`: delivered IQ pairs against the wall clock, measured at arrival. Measuring from the watchdog is not accurate enough — the librtlsdr queue delivers in 256 KB chunks (131072 pairs, ~110 ms at 2.4 Msps), so a 200 ms poll wobbles by more than one whole transfer; at arrival the noise floor is ~0.07 ms.

**A drop event** is a deficit growth over ~1 s beyond 2 ms of stream (`rate/500`):
- above the ±150 ppm crystal drift (≤ 480 pairs/s),
- far below one lost 256 KB transfer (131072 pairs).

Transient delivery spikes (ring buffer backpressure) recover and collapse the deficit again, so they **do not count**. Accounting is re-baselined whenever the callback was quiet for more than 150 ms (device startup, config reload on SIGHUP) and during the first 5 s ramp-up.

## Behaviour

- **Warning** on each event: ~N pairs lost (~X ms of stream), cumulative deficit.
- **Exit policy** on the watchdog side: more than 1 drop in 60 s terminates the process. Override with `STREAM1090_MAX_DROPS_PER_MIN` (`0` disables the exit, warnings stay on).

## How to test

`STREAM1090_MAX_DROPS_PER_MIN=0 ./build/stream1090 -d configs/rtlsdr.ini -q`

Stress the host (saturate the CPU, or use a shared USB hub) and watch for warnings; for the exit, leave the default and exceed 1 drop/min.

## Notes

- No change to the data path: `writeDataToBuffer` measures before writing into the buffer; zero impact on the samples themselves.
- Extracted from the 3.2 Msps branch (`cd02b6e` of PR #71), where it was needed to tell whether the measured loss was the dongle or the host.
