### PR TITLE
Gate backend presets on backend availability

### DIFF
--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <optional>
 #include <sstream>
+#include <thread>
 #include <unistd.h>
 
 

--- a/include/Presets.hpp
+++ b/include/Presets.hpp
@@ -44,6 +44,14 @@ constexpr auto presets = std::make_tuple(
 // rate-pair scanning, but dispatched from separate translation units (see
 // src/presets_rtlsdr.cpp / src/presets_airspy.cpp): each TU then compiles only
 // its own MainInstance<...> instantiations instead of all of them in main.cpp.
+//
+// Each preset instantiates the full templated DSP chain (MainInstance<P>),
+// so presets for a backend whose library was not detected by CMake would be
+// dead weight: the device factory cannot create the device they need and the
+// runtime can never select them. Each backend's tuple is therefore gated
+// behind its STREAM1090_HAVE_* define (set by CMake only when the library is
+// found) and is empty otherwise.
+#if defined(STREAM1090_HAVE_RTLSDR)
 constexpr auto rtlSdrPresets = std::make_tuple(
     // RTL-SDR (uint8) default presets
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_4_to_8_0_Mhz, IQPipelineOptions::NONE>{},
@@ -60,9 +68,13 @@ constexpr auto rtlSdrPresets = std::make_tuple(
 
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::NONE>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR>{},
-    Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{}  
+    Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{}
 );
+#else
+constexpr auto rtlSdrPresets = std::tuple<>{};
+#endif
 
+#if defined(STREAM1090_HAVE_AIRSPY)
 constexpr auto airspyPresets = std::make_tuple(
     // Airspy (uint16) default presets
     Preset<IQ_UINT16_RAW_AIRSPY, Sampler_6_0_to_6_0_Mhz, IQPipelineOptions::NONE>{},
@@ -96,6 +108,9 @@ constexpr auto airspyPresets = std::make_tuple(
     Preset<IQ_UINT16_RAW_AIRSPY, Sampler_10_0_to_48_0_Mhz, IQPipelineOptions::IQ_FIR_FILE>{}
 #endif
 );
+#else
+constexpr auto airspyPresets = std::tuple<>{};
+#endif
 
 // Combined tuple, used only for rate-pair scanning (constexpr metadata, no
 // code instantiation). Dispatch goes through the per-backend tuples above.


### PR DESCRIPTION
## What

Gate the backend presets on the same `STREAM1090_HAVE_*` defines CMake already sets when it finds the library, plus a CI report that measures the result.

## preset gating (`include/Presets.hpp`)

Each entry in the presets tuple instantiates a full templated DSP chain (`MainInstance<P>`), so presets for a backend whose library was not detected are dead code: the device factory can never create that device and the runtime can never select it.

The backend presets are now built with `std::tuple_cat`, keeping each backend's chunk only when its `STREAM1090_HAVE_*` define is set.

Measured (macOS, Apple clang, Release):
- no backend libraries: **~1150 KB → ~80 KB** (−93%), and unsupported rates now fail early at argument validation instead of at device open.
