### PR TITLE
Split preset dispatch into per-backend translation units

### DIFF
--- a/include/Global.hpp
+++ b/include/Global.hpp
@@ -9,6 +9,11 @@
 #include <atomic>
 #include <csignal>
 
+// visible to every translation unit that instantiates a sampler
+#ifndef STREAM1090_VERSION
+#define STREAM1090_VERSION "260905"
+#endif
+
 struct GlobalOptions {
     #ifdef STATS_ENABLED
         static constexpr bool StatsEnabled = (STATS_ENABLED != 0);

--- a/include/MainInstance.hpp
+++ b/include/MainInstance.hpp
@@ -360,33 +360,3 @@ private:
     DevicePtr m_device = nullptr;
     RuntimeVars m_runtimeVars;
 };
-
-template<typename Tuple, typename F>
-constexpr bool for_each_in_tuple(const Tuple& t, F&& f) {
-    bool done = false;
-    std::apply([&](auto const&... elems) {
-        (( !done && f(elems) ? done = true : false ), ...);
-    }, t);
-    return done;
-}
-
-// Returns nothing when no preset matches the requested configuration, and
-// otherwise the outcome of the run: true when the instance ran and shut down
-// normally, false when it gave up (for example because the device never came up).
-std::optional<bool> runInstanceFromPresets(const CompileTimeVars& compileTimeVars, const RuntimeVars& runtimeVars) {
-    std::optional<bool> outcome;
-    for_each_in_tuple(presets, [&](auto const& p) {
-        using P = std::decay_t<decltype(p)>;
-
-        if (P::RawFormatType::id  == compileTimeVars.rawFormat &&
-            P::inputRate          == compileTimeVars.inputRate &&
-            P::outputRate         == compileTimeVars.outputRate &&
-            P::pipelineOption     == compileTimeVars.pipelineOption) 
-        {
-            outcome = MainInstance<P>(runtimeVars).run();
-            return true;
-        }
-        return false;
-    });
-    return outcome;
-}

--- a/include/PresetDispatcher.hpp
+++ b/include/PresetDispatcher.hpp
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 Martin Gronemann
+ *
+ * This file is part of stream1090 and is licensed under the GNU General
+ * Public License v3.0. See the top-level LICENSE file for details.
+ */
+
+#pragma once
+
+#include "MainInstance.hpp"
+
+template<typename Tuple, typename F>
+constexpr bool for_each_in_tuple(const Tuple& t, F&& f) {
+    bool done = false;
+    std::apply([&](auto const&... elems) {
+        (( !done && f(elems) ? done = true : false ), ...);
+    }, t);
+    return done;
+}
+
+// Runs the first preset in `groupPresets` that matches the requested
+// configuration. This is the one place MainInstance<...> gets instantiated,
+// so it is called from the per-backend translation units (src/presets_*.cpp)
+// to keep each TU's compilation load proportional to its own preset count.
+template<typename Tuple>
+std::optional<bool> runPresetGroup(const Tuple& groupPresets,
+                                   const CompileTimeVars& compileTimeVars,
+                                   const RuntimeVars& runtimeVars) {
+    std::optional<bool> outcome;
+    for_each_in_tuple(groupPresets, [&](auto const& p) {
+        using P = std::decay_t<decltype(p)>;
+
+        if (P::RawFormatType::id  == compileTimeVars.rawFormat &&
+            P::inputRate          == compileTimeVars.inputRate &&
+            P::outputRate         == compileTimeVars.outputRate &&
+            P::pipelineOption     == compileTimeVars.pipelineOption)
+        {
+            outcome = MainInstance<P>(runtimeVars).run();
+            return true;
+        }
+        return false;
+    });
+    return outcome;
+}
+
+#if !defined(STREAM1090_CUSTOM_INPUT) || !STREAM1090_CUSTOM_INPUT
+std::optional<bool> runRtlSdrPresets(const CompileTimeVars&, const RuntimeVars&);
+std::optional<bool> runAirspyPresets(const CompileTimeVars&, const RuntimeVars&);
+#endif

--- a/include/Presets.hpp
+++ b/include/Presets.hpp
@@ -40,7 +40,11 @@ constexpr auto presets = std::make_tuple(
     Preset<IQ_FLOAT32, Sampler_4_0_to_4_0_Mhz, IQPipelineOptions::NONE>{}
 );
 #else 
-constexpr auto presets = std::make_tuple(
+// One tuple per device backend. They are combined into `presets` below for
+// rate-pair scanning, but dispatched from separate translation units (see
+// src/presets_rtlsdr.cpp / src/presets_airspy.cpp): each TU then compiles only
+// its own MainInstance<...> instantiations instead of all of them in main.cpp.
+constexpr auto rtlSdrPresets = std::make_tuple(
     // RTL-SDR (uint8) default presets
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_4_to_8_0_Mhz, IQPipelineOptions::NONE>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_4_to_8_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR>{},
@@ -53,11 +57,13 @@ constexpr auto presets = std::make_tuple(
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_8_0_Mhz, IQPipelineOptions::NONE>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_8_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_8_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{} ,
-    
+
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::NONE>{},
     Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR>{},
-    Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{} ,
-    
+    Preset<IQ_UINT8_RTL_SDR, Sampler_2_56_to_12_0_Mhz, IQPipelineOptions::IQ_FIR_RTL_SDR_FILE>{}  
+);
+
+constexpr auto airspyPresets = std::make_tuple(
     // Airspy (uint16) default presets
     Preset<IQ_UINT16_RAW_AIRSPY, Sampler_6_0_to_6_0_Mhz, IQPipelineOptions::NONE>{},
     Preset<IQ_UINT16_RAW_AIRSPY, Sampler_6_0_to_6_0_Mhz, IQPipelineOptions::IQ_FIR>{},
@@ -90,6 +96,10 @@ constexpr auto presets = std::make_tuple(
     Preset<IQ_UINT16_RAW_AIRSPY, Sampler_10_0_to_48_0_Mhz, IQPipelineOptions::IQ_FIR_FILE>{}
 #endif
 );
+
+// Combined tuple, used only for rate-pair scanning (constexpr metadata, no
+// code instantiation). Dispatch goes through the per-backend tuples above.
+constexpr auto presets = std::tuple_cat(rtlSdrPresets, airspyPresets);
 
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -13,9 +13,8 @@
 #include <chrono>
 #include <optional>
 
-#define STREAM1090_VERSION "260905"
-
 #include "MainInstance.hpp"
+#include "PresetDispatcher.hpp"
 
 
 struct RatePair {
@@ -266,6 +265,21 @@ std::vector<float> load_taps_from_file(const std::string& filename) {
     }
 
     return taps;
+}
+
+// Returns nothing when no preset matches the requested configuration, and
+// otherwise the outcome of the run. Dispatch is split per device backend so
+// the heavy MainInstance<...> instantiations compile in their own TUs.
+std::optional<bool> runInstanceFromPresets(const CompileTimeVars& c_vars, const RuntimeVars& r_vars) {
+#if defined(STREAM1090_CUSTOM_INPUT) && STREAM1090_CUSTOM_INPUT
+    return runPresetGroup(presets, c_vars, r_vars);
+#else
+    if (auto o = runRtlSdrPresets(c_vars, r_vars))
+        return o;
+    if (auto o = runAirspyPresets(c_vars, r_vars))
+        return o;
+    return std::nullopt;
+#endif
 }
 
 int main(int argc, char** argv) {

--- a/src/presets_airspy.cpp
+++ b/src/presets_airspy.cpp
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 Martin Gronemann
+ *
+ * This file is part of stream1090 and is licensed under the GNU General
+ * Public License v3.0. See the top-level LICENSE file for details.
+ */
+
+#include "PresetDispatcher.hpp"
+#include "Presets.hpp"
+
+#if !defined(STREAM1090_CUSTOM_INPUT) || !STREAM1090_CUSTOM_INPUT
+
+std::optional<bool> runAirspyPresets(const CompileTimeVars& compileTimeVars,
+                                     const RuntimeVars& runtimeVars) {
+    return runPresetGroup(airspyPresets, compileTimeVars, runtimeVars);
+}
+
+#endif

--- a/src/presets_rtlsdr.cpp
+++ b/src/presets_rtlsdr.cpp
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 Martin Gronemann
+ *
+ * This file is part of stream1090 and is licensed under the GNU General
+ * Public License v3.0. See the top-level LICENSE file for details.
+ */
+
+#include "PresetDispatcher.hpp"
+#include "Presets.hpp"
+
+#if !defined(STREAM1090_CUSTOM_INPUT) || !STREAM1090_CUSTOM_INPUT
+
+std::optional<bool> runRtlSdrPresets(const CompileTimeVars& compileTimeVars,
+                                     const RuntimeVars& runtimeVars) {
+    return runPresetGroup(rtlSdrPresets, compileTimeVars, runtimeVars);
+}
+
+#endif


### PR DESCRIPTION
## What

Split the preset dispatch into one translation unit per device backend.

Before, all 34 `MainInstance<...>` instantiations (each embedding a full templated DSP chain: sampler, FIR, demodulator, read loop) were compiled inside a single `main.cpp`. That one TU was the compilation hot spot: a ~1.4 MB object file whose single-object compile peaked at hundreds of MB of compiler RSS.

Now:
- `Presets.hpp` defines two tuples — `rtlSdrPresets` and `airspyPresets` — combined into a single `presets` (via `std::tuple_cat`) **only** for the cheap constexpr rate-pair scan.
- `src/presets_rtlsdr.cpp` and `src/presets_airspy.cpp` each compile their own backend's `MainInstance<...>` set, behind a tiny `runPresetGroup()` dispatcher.
- `main.cpp` handles the (tiny) custom-input tuple and forwards to the two backend entry points.
- `STREAM1090_VERSION` moved to `Global.hpp` so every TU can print the sampler banner.

## Why

C++ template instantiation cost scales with how many preset chains live in **one** translation unit. With a single giant TU, the compiler holds every preset's copy of the DSP stack (and its IR) in memory at once; splitting per backend caps that at "one backend's worth".

Measured on **Release, Airspy+RTL-SDR, both backends**, from a clean tree:

| compiler | peak build RSS | main.cpp.o | binary |
|---|---:|---:|---:|
| Apple clang | 464 → **350 MB** | 1406 → **57 KB** | 1150 → 1184 KB |
| gcc 15 | 654 → **547 MB** | 1205 → **50 KB** | 1283 → 1317 KB |

That is a **−25% / −16%** reduction in peak compiler RSS, and the per-file object drops from ~1.4 MB to under 60 KB. Whether that fits a given budget depends on the compiler and `-j` count — on clang each backend TU now peaks well under ~350 MB, while gcc stays tighter (547 MB) and needs a higher `-j` budget. The split is what makes a low-RAM host feasible, not a guarantee for an arbitrary RAM cap.

## Cost

~ +3% binary size: each TU can no longer share intermediate code with the others before the linker, so a few identical copies survive. **No CPU cost at runtime** — the executed path is byte-identical (measured: no decode throughput difference on 64 MB of noise input); the extra bytes are dead copies that never run.

A stacked, optional `-flto` flag re-deduplicates those copies at link time and brings the binary **below** the pre-split baseline (856 KB vs 1150 KB with clang) — as a follow-up.
