### PR TITLE
Confirm sample deficits before reporting drops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if(BUILD_TESTING)
     stream1090_add_test(mode_s_altitude_test tests/ModeSAltitudeTest.cpp)
     stream1090_add_test(mode_s_position_test tests/ModeSPositionTest.cpp)
     stream1090_add_test(rtlsdr_serial_test tests/RtlSdrSerialTest.cpp)
+    stream1090_add_test(sample_drop_event_gate_test tests/SampleDropEventGateTest.cpp)
     stream1090_add_test(noise_false_positive_test tests/NoiseFalsePositiveTest.cpp)
     target_compile_definitions(noise_false_positive_test PRIVATE
         ${PREAMBLE_GATE_DEF}

--- a/include/devices/InputDeviceBase.hpp
+++ b/include/devices/InputDeviceBase.hpp
@@ -9,6 +9,7 @@
 #include "Sampler.hpp"
 #include "RingBuffer.hpp"
 #include "IniConfig.hpp"
+#include "devices/SampleDropEventGate.hpp"
 #include <string>
 #include <atomic>
 #include <chrono>
@@ -23,7 +24,8 @@ public:
         : m_sampleRate(sampleRate), m_bufferWriter(bufferWriter),
           // a drop event must cost at least 2 ms of stream: far above the
           // +-100 ppm crystal drift, far below one 256 KB USB transfer
-          m_dropEventThreshold((uint64_t)sampleRate / 500)
+          m_dropEventThreshold((uint64_t)sampleRate / 500),
+          m_dropEventGate(m_dropEventThreshold)
     {
         m_lastSignOfLife.store(std::chrono::steady_clock::now(),
                              std::memory_order_relaxed);
@@ -63,7 +65,7 @@ public:
     // callback thread; the sample-drop accounting happens here because
     // only at arrival time is the wall clock comparable to the delivered
     // count without paying the quantization of the USB transfer queue
-    // (one 256 KB transfer = 131072 IQ pairs = ~110 ms at 2.4 Msps).
+    // (one 256 KB transfer = 131072 IQ pairs = ~55 ms at 2.4 Msps).
     void writeDataToBuffer(const T* data, size_t n) {
         const auto now = std::chrono::steady_clock::now();
         const uint64_t pairs = m_iqPairsDelivered.fetch_add(n / 2, std::memory_order_relaxed)
@@ -83,6 +85,7 @@ public:
             m_accT0 = now;
             m_accPairs0 = pairs;
             m_histCount = 0;
+            m_dropEventGate.reset();
             m_dropDeficit.store(0, std::memory_order_relaxed);
         } else {
             const double secs = std::chrono::duration<double>(now - m_accT0).count();
@@ -111,28 +114,32 @@ public:
                 // crystal offset makes the cumulative deficit drift at up
                 // to ~150 ppm (under 500 pairs per second, far below the
                 // event threshold). Comparing the deficit against ~1 s ago
-                // keeps both out: real loss arrives in whole USB transfers
-                // (131072 pairs) and dwarfs the drift.
+                // finds a candidate; SampleDropEventGate then gives the 15
+                // librtlsdr transfer buffers a full second to catch up before
+                // it confirms a loss.
                 m_deficitHist[m_histHead] = {now, deficit};
                 m_histHead = (m_histHead + 1) % kDeficitHistory;
                 if (m_histCount < kDeficitHistory)
                     m_histCount++;
 
-                // find the oldest sample that is at least 900 ms old
+                // Find the newest sample that is at least 900 ms old. head
+                // points at the next insertion slot; before the ring is full,
+                // starting at head would inspect zero-initialised entries.
                 int64_t past = -1;
+                const size_t oldest = (m_histHead + kDeficitHistory - m_histCount) % kDeficitHistory;
                 for (size_t i = 0; i < m_histCount; i++) {
-                    const auto& s = m_deficitHist[(m_histHead + i) % kDeficitHistory];
+                    const auto& s = m_deficitHist[(oldest + i) % kDeficitHistory];
                     if (now - s.t >= std::chrono::milliseconds(900)) {
                         past = s.deficit;
                     } else {
                         break;
                     }
                 }
-                if (past >= 0 && deficit - past > (int64_t)m_dropEventThreshold &&
-                    now - m_lastEventTime > std::chrono::milliseconds(500)) {
-                    m_lastEventGrowth = deficit - past;
-                    m_lastEventTime = now;
-                    m_dropEvents.fetch_add(1, std::memory_order_relaxed);
+                if (past >= 0) {
+                    if (const auto growth = m_dropEventGate.observe(now, deficit, past)) {
+                        m_lastEventGrowth = *growth;
+                        m_dropEvents.fetch_add(1, std::memory_order_relaxed);
+                    }
                 }
             }
         }
@@ -188,8 +195,8 @@ protected:
     std::atomic<std::chrono::steady_clock::time_point> m_lastSignOfLife;
 
     // ---- sample-drop accounting, callback thread only ----
-    // deficit history: 32 samples cover well over 1 s of callbacks (one
-    // callback per 256 KB transfer = ~82-110 ms)
+    // Deficit history: at the fastest RTL-SDR preset, 32 default 256 KB
+    // transfers cover about 1.3 seconds (one transfer is 131072 IQ pairs).
     static constexpr size_t kDeficitHistory = 32;
     struct DeficitSample {
         std::chrono::steady_clock::time_point t;
@@ -198,12 +205,12 @@ protected:
     DeficitSample m_deficitHist[kDeficitHistory]{};
     size_t m_histHead = 0;
     size_t m_histCount = 0;
-    std::chrono::steady_clock::time_point m_lastEventTime{};
     std::chrono::steady_clock::time_point m_lastAccounting{};
     std::chrono::steady_clock::time_point m_firstCallback{};
     std::chrono::steady_clock::time_point m_accT0{};
     uint64_t m_accPairs0 = 0;
     const uint64_t m_dropEventThreshold;
+    SampleDropEventGate m_dropEventGate;
     std::atomic<int64_t> m_dropDeficit{0};
     std::atomic<int64_t> m_lastEventGrowth{0};
     std::atomic<uint64_t> m_dropEvents{0};

--- a/include/devices/SampleDropEventGate.hpp
+++ b/include/devices/SampleDropEventGate.hpp
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2026 Martin Gronemann
+ *
+ * This file is part of stream1090 and is licensed under the GNU General
+ * Public License v3.0. See the top-level LICENSE file for details.
+ */
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+
+// Turns changes in the sample-clock deficit into distinct drop events.
+//
+// A callback arriving late creates exactly the same instantaneous deficit as
+// a real FIFO/USB loss. The difference is that queued samples subsequently
+// catch up. Therefore a threshold crossing is only a candidate: it must remain
+// above the pre-event baseline for a recovery window before it is reported.
+// After reporting, the gate stays latched until the rolling comparison has
+// absorbed the step, so one missing transfer cannot be counted repeatedly.
+class SampleDropEventGate {
+public:
+  using Clock = std::chrono::steady_clock;
+  static constexpr auto RecoveryWindow = std::chrono::seconds(1);
+
+  explicit SampleDropEventGate(uint64_t threshold)
+      : m_threshold(static_cast<int64_t>(threshold)) {}
+
+  std::optional<int64_t> observe(Clock::time_point now, int64_t deficit,
+                                 int64_t pastDeficit) {
+    const int64_t rollingGrowth = deficit - pastDeficit;
+
+    switch (m_state) {
+    case State::Idle:
+      if (rollingGrowth > m_threshold) {
+        m_state = State::Pending;
+        m_candidateStart = now;
+        m_candidateBaseline = pastDeficit;
+        m_candidateMinimumGrowth = rollingGrowth;
+      }
+      break;
+
+    case State::Pending: {
+      const int64_t residualGrowth = deficit - m_candidateBaseline;
+      if (residualGrowth <= m_threshold) {
+        // The callback queue caught up: no samples were lost.
+        m_state = State::Idle;
+        break;
+      }
+
+      m_candidateMinimumGrowth =
+          std::min(m_candidateMinimumGrowth, residualGrowth);
+      if (now - m_candidateStart >= RecoveryWindow) {
+        m_state = State::Latched;
+        return m_candidateMinimumGrowth;
+      }
+      break;
+    }
+
+    case State::Latched:
+      // Wait until the pre-event value has left the rolling comparison
+      // window. This makes a persistent step one event, not one event
+      // per cooldown period.
+      if (rollingGrowth <= m_threshold)
+        m_state = State::Idle;
+      break;
+    }
+
+    return std::nullopt;
+  }
+
+  void reset() { m_state = State::Idle; }
+
+private:
+  enum class State { Idle, Pending, Latched };
+
+  const int64_t m_threshold;
+  State m_state = State::Idle;
+  Clock::time_point m_candidateStart{};
+  int64_t m_candidateBaseline = 0;
+  int64_t m_candidateMinimumGrowth = 0;
+};

--- a/tests/SampleDropEventGateTest.cpp
+++ b/tests/SampleDropEventGateTest.cpp
@@ -1,0 +1,93 @@
+#include "devices/SampleDropEventGate.hpp"
+
+#include <chrono>
+#include <iostream>
+
+namespace {
+using namespace std::chrono_literals;
+using Clock = SampleDropEventGate::Clock;
+
+bool expectNoEvent(std::optional<int64_t> event, const char *where) {
+  if (!event)
+    return true;
+  std::cerr << where << ": unexpected event of " << *event << " pairs\n";
+  return false;
+}
+} // namespace
+
+int main() {
+  constexpr uint64_t threshold = 5120; // 2 ms at 2.56 Msps
+  const auto t0 = Clock::time_point{} + 10s;
+
+  // A callback is late by 2.7 ms, then the queued samples catch up. This is
+  // the shape from the field report (6854 pairs followed by 226): it must
+  // never become a loss event.
+  SampleDropEventGate recovered(threshold);
+  if (!expectNoEvent(recovered.observe(t0, 6854, 0), "recovered/start"))
+    return 1;
+  if (!expectNoEvent(recovered.observe(t0 + 100ms, 226, 0),
+                     "recovered/catch-up"))
+    return 2;
+  if (!expectNoEvent(recovered.observe(t0 + 2s, 100, 100), "recovered/settled"))
+    return 3;
+
+  // Recovery just before the deadline is still recovery. In particular, the
+  // gate must not turn the candidate into an event merely because it was high
+  // for most of the confirmation window.
+  SampleDropEventGate slowRecovery(threshold);
+  if (!expectNoEvent(slowRecovery.observe(t0, 13614, 0), "slow/start"))
+    return 14;
+  if (!expectNoEvent(slowRecovery.observe(t0 + 800ms, 13000, 0), "slow/wait"))
+    return 15;
+  if (!expectNoEvent(slowRecovery.observe(t0 + 999ms, 41, 0), "slow/catch-up"))
+    return 16;
+  if (!expectNoEvent(slowRecovery.observe(t0 + 2s, 100, 100), "slow/settled"))
+    return 17;
+
+  // A real loss remains above the pre-event deficit for the entire recovery
+  // window and is reported once, using the minimum residual rather than the
+  // transient peak.
+  SampleDropEventGate persistent(threshold);
+  if (!expectNoEvent(persistent.observe(t0, 7000, 0), "persistent/start"))
+    return 4;
+  if (!expectNoEvent(persistent.observe(t0 + 500ms, 6800, 0),
+                     "persistent/wait"))
+    return 5;
+  const auto first = persistent.observe(t0 + 1s, 6700, 0);
+  if (!first || *first != 6700) {
+    std::cerr << "persistent/confirm: expected one 6700-pair event\n";
+    return 6;
+  }
+
+  // The same persistent step must not be emitted again. Once it has moved
+  // into both sides of the rolling comparison, a later independent step can
+  // arm the gate again.
+  if (!expectNoEvent(persistent.observe(t0 + 1500ms, 6700, 0),
+                     "persistent/latched"))
+    return 7;
+  if (!expectNoEvent(persistent.observe(t0 + 2s, 6700, 6700),
+                     "persistent/rearm"))
+    return 8;
+  if (!expectNoEvent(persistent.observe(t0 + 2100ms, 13700, 6700),
+                     "second/start"))
+    return 9;
+  if (!expectNoEvent(persistent.observe(t0 + 2700ms, 13600, 6700),
+                     "second/wait"))
+    return 10;
+  const auto second = persistent.observe(t0 + 3100ms, 13500, 6700);
+  if (!second || *second != 6800) {
+    std::cerr << "second/confirm: expected one 6800-pair event\n";
+    return 11;
+  }
+
+  // Resetting after an intentional/driver gap also discards a pending
+  // candidate; the post-gap stream starts with a clean detector state.
+  SampleDropEventGate reset(threshold);
+  if (!expectNoEvent(reset.observe(t0, 9000, 0), "reset/start"))
+    return 12;
+  reset.reset();
+  if (!expectNoEvent(reset.observe(t0 + 2s, 100, 100), "reset/after"))
+    return 13;
+
+  return 0;
+}


### PR DESCRIPTION
Follow-up to #74. The sample-drop monitor reports drops that never happened, and the default exit policy (more than 1 drop per 60 s) then shuts the process down.

## The field report

A user on the FlightAware thread hit this on a Raspberry Pi 5 with an SSD and plenty of CPU headroom, running a FlightAware Pro Stick Plus v1.0 through a 3 m USB extension. stream1090 died within a minute of start, at both 2.4 and 2.56 Msps, after weeks of stable operation on an older build:

```
11:56:05.689 [Watchdog] Sample drop: ~6862 IQ pairs (~2.85917 ms of stream) lost; cumulative deficit ~88 IQ pairs.
11:56:09.890 [Watchdog] Sample drop: ~7079 IQ pairs (~2.94958 ms of stream) lost; cumulative deficit ~7200 IQ pairs.
11:56:09.890 [Watchdog] 2 sample drops in the last 60 s (threshold: more than 1). The host cannot sustain this sample rate. Initiating shutdown.
```

The first line refutes itself: 6862 pairs cannot have been lost while the cumulative deficit is 88. `rtl_test -s 2400000` on the same host loses a few bytes at startup and is then stable, and the PPM is within a couple of ppm cumulative, so the hardware is fine.

Report: https://discussions.flightaware.com/t/stream1090/99603/762 — confirmation that this branch fixes it: https://discussions.flightaware.com/t/stream1090/99603/767

## Two faults, both in the ~1 s rolling comparison

**1. The history scan reads the wrong slots.** It starts at `m_histHead`, which is the oldest entry only once the ring is full. Before that — the first 32 accounting samples, and after every re-baseline, which clears `m_histCount` but leaves the ring contents — it walks zero-initialised or stale slots instead of the real ones. Their timestamp is the `steady_clock` epoch, so they always pass the "at least 900 ms old" test, and `past` comes out as 0 instead of the deficit one second ago. Any momentary deficit above the 2 ms threshold then reads as growth out of nothing. That is exactly the log above: ~6800 pairs "lost" against a baseline of zero, while the actual cumulative deficit had already collapsed back to 88.

The scan now starts at `(head - count)`.

**2. A late callback is indistinguishable from a loss at the moment it arrives.** Both produce the same instantaneous deficit. The difference only shows up afterwards: queued samples arrive and the deficit collapses, whereas a lost sample never comes back. A USB extension, a shared hub or a scheduling hiccup makes the late callback routine, and the old code counted it immediately.

`SampleDropEventGate` (new header) therefore treats a threshold crossing as a *candidate* and confirms it only if the deficit stays above the pre-event baseline for a full second — the time librtlsdr's 15 queued transfer buffers need to catch up. It reports the minimum residual over that window rather than the transient peak, and then latches until the step has passed through both sides of the rolling comparison, so one lost transfer is one event rather than one event per 500 ms cooldown.

## What this does not change

The detection thresholds, the exit policy and the log format are untouched. A host that genuinely cannot sustain the rate still loses whole 256 KB transfers (131072 pairs), which dwarfs the 2 ms threshold and persists for far longer than the confirmation window, so it is still caught — one second later than before.

Also corrected: one 256 KB transfer is 131072 IQ pairs, i.e. ~55 ms at 2.4 Msps, not ~110 ms. Two comments said the latter.

## Testing

- New `sample_drop_event_gate_test` covers the recovery shape from the field report (6854 pairs followed by 226), recovery just before the deadline, a real persistent loss reported exactly once, re-arming for a second independent step, and `reset()` discarding a pending candidate.
- The reporter built this branch on the affected Pi 5 and reports it running stable ("It runs stable at the moment"); they are still watching it, so that is a short observation rather than a long soak.
